### PR TITLE
Applying consistent folder name formatting to Credentials

### DIFF
--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -8,11 +8,12 @@ Manages a folder within Jenkins.
 
 ```hcl
 resource jenkins_folder example {
-    name = "folder-name"
+  name = "folder-name"
 }
 
 resource jenkins_folder example_child {
-    name = "${jenkins_folder.example.name}/child-name"
+  name   = "child-name"
+  folder = jenkins_folder.example.id
 }
 ```
 
@@ -20,7 +21,8 @@ resource jenkins_folder example_child {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the folder being created. If creating in a subfolder separate folder names with `/`, such as `parent/child`. This name cannot be changed once the folder has been created, and all parent folders must be created in advance.
+* `name` - (Required) The name of the folder being created.
+* `folder` - (Optional) The folder namespace to store the subfolder in. If creating in a nested folder structure you may separate folder names with `/`, such as `parent/child`. This name cannot be changed once the folder has been created, and all parent folders must be created in advance.
 * `description` - (Optional) A block of text describing the folder's purpose.
 * `template` - (Optional) A Jenkins-compatible XML template to describe the folder. You can retrieve an existing folder's XML by appending `/config.xml` to its URL and viewing the source in your browser. The `template` property is rendered using a Golang template that takes the other resource arguments as variables. Do not include the XML prolog in the definition. If `template` is not provided this will default to a "best-guess" folder definition.
 * `permissions` - (Optional) A list of strings containing Jenkins permissions assigments to users and groups for the folder. For example:

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -5,8 +5,13 @@ Manages a job within Jenkins.
 ## Example Usage
 
 ```hcl
+resource jenkins_folder example {
+  name = "folder-name"
+}
+
 resource jenkins_job example {
   name     = "example"
+  folder   = jenkins_folder.example.id
   template = file("${path.module}/job.xml")
 
   parameters = {
@@ -53,7 +58,8 @@ And in `job.xml`:
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the job being created. If creating in a subfolder separate folder names with `/`, such as `parent/child`. This name cannot be changed once the job has been created, and all parent folders must be created in advance.
+* `name` - (Required) The name of the job being created.
+* `folder` - (Optional) The folder namespace to store the job in. If creating in a nested folder structure you may separate folder names with `/`, such as `parent/child`. This name cannot be changed once the folder has been created, and all parent folders must be created in advance.
 * `parameters` - (Optional) A map of string values that are passed into the template for rendering.
 * `template` - (Required) A Jenkins-compatible XML template to describe the job. You can retrieve an existing jobs' XML by appending `/config.xml` to its URL and viewing the source in your browser. The `template` property is rendered using a Golang template that takes the other resource arguments as variables. Do not include the XML prolog in the definition.
 

--- a/jenkins/config.go
+++ b/jenkins/config.go
@@ -3,6 +3,7 @@ package jenkins
 import (
 	"io"
 	"io/ioutil"
+	"strings"
 
 	jenkins "github.com/bndr/gojenkins"
 )
@@ -10,8 +11,9 @@ import (
 type jenkinsClient interface {
 	CreateJobInFolder(config string, jobName string, parentIDs ...string) (*jenkins.Job, error)
 	Credentials() *jenkins.CredentialsManager
-	DeleteJob(name string) (bool, error)
+	DeleteJobInFolder(name string, parentIDs ...string) (bool, error)
 	GetJob(id string, parentIDs ...string) (*jenkins.Job, error)
+	GetFolder(id string, parents ...string) (*jenkins.Folder, error)
 }
 
 // jenkinsAdapter wraps the Jenkins client, enabling additional functionality
@@ -42,4 +44,10 @@ func (j *jenkinsAdapter) Credentials() *jenkins.CredentialsManager {
 	return &jenkins.CredentialsManager{
 		J: j.Jenkins,
 	}
+}
+
+// DeleteJobInFolder assists in running DeleteJob funcs, as DeleteJob is not folder aware
+// and cannot take a canonical job ID without mishandling it.
+func (j *jenkinsAdapter) DeleteJobInFolder(name string, parentIDs ...string) (bool, error) {
+	return j.DeleteJob(strings.Join(append(parentIDs, name), "/job/"))
 }

--- a/jenkins/config_test.go
+++ b/jenkins/config_test.go
@@ -9,8 +9,9 @@ import (
 
 type mockJenkinsClient struct {
 	mockCreateJobInFolder func(config string, jobName string, parentIDs ...string) (*jenkins.Job, error)
-	mockDeleteJob         func(name string) (bool, error)
+	mockDeleteJobInFolder func(name string, parentIDs ...string) (bool, error)
 	mockGetJob            func(id string, parentIDs ...string) (*jenkins.Job, error)
+	mockGetFolder         func(id string, parentIDs ...string) (*jenkins.Folder, error)
 }
 
 func (m *mockJenkinsClient) CreateJobInFolder(config string, jobName string, parentIDs ...string) (*jenkins.Job, error) {
@@ -21,12 +22,16 @@ func (m *mockJenkinsClient) Credentials() *jenkins.CredentialsManager {
 	return &jenkins.CredentialsManager{}
 }
 
-func (m *mockJenkinsClient) DeleteJob(name string) (bool, error) {
-	return m.mockDeleteJob(name)
+func (m *mockJenkinsClient) DeleteJobInFolder(name string, parentIDs ...string) (bool, error) {
+	return m.mockDeleteJobInFolder(name, parentIDs...)
 }
 
 func (m *mockJenkinsClient) GetJob(id string, parentIDs ...string) (*jenkins.Job, error) {
 	return m.mockGetJob(id, parentIDs...)
+}
+
+func (m *mockJenkinsClient) GetFolder(id string, parentIDs ...string) (*jenkins.Folder, error) {
+	return m.mockGetFolder(id, parentIDs...)
 }
 
 func TestNewJenkinsClient(t *testing.T) {

--- a/jenkins/resource_jenkins_credential_username.go
+++ b/jenkins/resource_jenkins_credential_username.go
@@ -76,10 +76,10 @@ func resourceJenkinsCredentialUsernameCreate(ctx context.Context, d *schema.Reso
 	cm := client.Credentials()
 
 	// Validate that the folder exists
-	cm.Folder = d.Get("folder").(string)
+	cm.Folder = formatJobName(d.Get("folder").(string))
 	if cm.Folder != "" {
-		if _, err := client.GetJob(cm.Folder); err != nil {
-			return diag.Errorf("Invalid folder name '%s' specified: %s", cm.Folder, err)
+		if _, err := client.GetJob(formatJobName(cm.Folder)); err != nil {
+			return diag.Errorf("Invalid folder name '%s' specified: %s", formatJobName(cm.Folder), err)
 		}
 	}
 
@@ -97,13 +97,13 @@ func resourceJenkinsCredentialUsernameCreate(ctx context.Context, d *schema.Reso
 		return diag.Errorf("Could not create username credentials: %s", err)
 	}
 
-	d.SetId(generateCredentialID(cm.Folder, cred.ID))
+	d.SetId(generateCredentialID(d.Get("folder").(string), cred.ID))
 	return resourceJenkinsCredentialUsernameRead(ctx, d, meta)
 }
 
 func resourceJenkinsCredentialUsernameRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cm := meta.(jenkinsClient).Credentials()
-	cm.Folder = d.Get("folder").(string)
+	cm.Folder = formatJobName(d.Get("folder").(string))
 
 	cred := jenkins.UsernameCredentials{}
 	err := cm.GetSingle(
@@ -122,7 +122,7 @@ func resourceJenkinsCredentialUsernameRead(ctx context.Context, d *schema.Resour
 		return diag.Errorf("Could not read username credentials: %s", err)
 	}
 
-	d.SetId(generateCredentialID(cm.Folder, cred.ID))
+	d.SetId(generateCredentialID(d.Get("folder").(string), cred.ID))
 	d.Set("scope", cred.Scope)
 	d.Set("description", cred.Description)
 	d.Set("username", cred.Username)
@@ -134,7 +134,7 @@ func resourceJenkinsCredentialUsernameRead(ctx context.Context, d *schema.Resour
 
 func resourceJenkinsCredentialUsernameUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cm := meta.(jenkinsClient).Credentials()
-	cm.Folder = d.Get("folder").(string)
+	cm.Folder = formatJobName(d.Get("folder").(string))
 
 	domain := d.Get("domain").(string)
 	cred := jenkins.UsernameCredentials{
@@ -154,13 +154,13 @@ func resourceJenkinsCredentialUsernameUpdate(ctx context.Context, d *schema.Reso
 		return diag.Errorf("Could not update username credentials: %s", err)
 	}
 
-	d.SetId(generateCredentialID(cm.Folder, cred.ID))
+	d.SetId(generateCredentialID(d.Get("folder").(string), cred.ID))
 	return resourceJenkinsCredentialUsernameRead(ctx, d, meta)
 }
 
 func resourceJenkinsCredentialUsernameDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cm := meta.(jenkinsClient).Credentials()
-	cm.Folder = d.Get("folder").(string)
+	cm.Folder = formatJobName(d.Get("folder").(string))
 
 	err := cm.Delete(
 		d.Get("domain").(string),

--- a/jenkins/resource_jenkins_credential_username.go
+++ b/jenkins/resource_jenkins_credential_username.go
@@ -78,7 +78,7 @@ func resourceJenkinsCredentialUsernameCreate(ctx context.Context, d *schema.Reso
 	// Validate that the folder exists
 	cm.Folder = d.Get("folder").(string)
 	if cm.Folder != "" {
-		if _, err := client.GetJob(formatJobName(cm.Folder)); err != nil {
+		if _, err := client.GetJob(cm.Folder); err != nil {
 			return diag.Errorf("Invalid folder name '%s' specified: %s", cm.Folder, err)
 		}
 	}

--- a/jenkins/resource_jenkins_credential_username_test.go
+++ b/jenkins/resource_jenkins_credential_username_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	jenkins "github.com/bndr/gojenkins"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -40,9 +41,88 @@ func TestAccJenkinsCredentialUsername_basic(t *testing.T) {
 				  password = "bar"
 				}`),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("jenkins_credential_username.foo", "description", "new-description"),
 					testAccCheckJenkinsCredentialUsernameExists("jenkins_credential_username.foo", &cred),
-					testAccCheckJenkinsCredentialUsernameDescriptionUpdated(&cred, "new-description"),
+					resource.TestCheckResourceAttr("jenkins_credential_username.foo", "description", "new-description"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccJenkinsCredentialUsername_folder(t *testing.T) {
+	var cred jenkins.UsernameCredentials
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckJenkinsCredentialUsernameDestroy,
+			testAccCheckJenkinsFolderDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource jenkins_folder foo {
+					name = "tf-acc-test-%s"
+					description = "Terraform acceptance testing"
+
+					lifecycle {
+						ignore_changes = [template]
+					}
+				}
+
+				resource jenkins_folder foo_sub {
+					name = "${jenkins_folder.foo.name}/subfolder"
+					description = "Terraform acceptance testing"
+
+					lifecycle {
+						ignore_changes = [template]
+					}
+				}
+
+				resource jenkins_credential_username foo {
+				  name = "test-username"
+				  folder = jenkins_folder.foo_sub.name
+				  username = "foo"
+				  password = "bar"
+				}`, randString),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("jenkins_credential_username.foo", "id", "tf-acc-test-"+randString+"/subfolder/test-username"),
+					testAccCheckJenkinsCredentialUsernameExists("jenkins_credential_username.foo", &cred),
+				),
+			},
+			{
+				// Update by adding description
+				Config: fmt.Sprintf(`
+				resource jenkins_folder foo {
+					name = "tf-acc-test-%s"
+					description = "Terraform acceptance testing"
+
+					lifecycle {
+						ignore_changes = [template]
+					}
+				}
+
+				resource jenkins_folder foo_sub {
+					name = "${jenkins_folder.foo.name}/subfolder"
+					description = "Terraform acceptance testing"
+
+					lifecycle {
+						ignore_changes = [template]
+					}
+				}
+
+				resource jenkins_credential_username foo {
+				  name = "test-username"
+				  folder = jenkins_folder.foo_sub.name
+				  description = "new-description"
+				  username = "foo"
+				  password = "bar"
+				}`, randString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckJenkinsCredentialUsernameExists("jenkins_credential_username.foo", &cred),
+					resource.TestCheckResourceAttr("jenkins_credential_username.foo", "description", "new-description"),
 				),
 			},
 		},
@@ -62,19 +142,11 @@ func testAccCheckJenkinsCredentialUsernameExists(resourceName string, cred *jenk
 			return fmt.Errorf("ID is not set")
 		}
 
-		err := client.Credentials().GetSingle(rs.Primary.Attributes["domain"], rs.Primary.Attributes["name"], cred)
+		manager := client.Credentials()
+		manager.Folder = formatJobName(rs.Primary.Attributes["folder"])
+		err := manager.GetSingle(rs.Primary.Attributes["domain"], rs.Primary.Attributes["name"], cred)
 		if err != nil {
-			return fmt.Errorf("Unable to retrieve credentials for %s: %w", rs.Primary.ID, err)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckJenkinsCredentialUsernameDescriptionUpdated(cred *jenkins.UsernameCredentials, description string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if cred.Description != description {
-			return fmt.Errorf("Description was not set")
+			return fmt.Errorf("Unable to retrieve credentials for %s - %s: %w", rs.Primary.Attributes["folder"], rs.Primary.Attributes["name"], err)
 		}
 
 		return nil
@@ -90,9 +162,11 @@ func testAccCheckJenkinsCredentialUsernameDestroy(s *terraform.State) error {
 		}
 
 		cred := jenkins.UsernameCredentials{}
-		err := client.Credentials().GetSingle(rs.Primary.Meta["domain"].(string), rs.Primary.Meta["name"].(string), &cred)
+		manager := client.Credentials()
+		manager.Folder = formatJobName(rs.Primary.Meta["folder"].(string))
+		err := manager.GetSingle(rs.Primary.Meta["domain"].(string), rs.Primary.Meta["name"].(string), &cred)
 		if err == nil {
-			return fmt.Errorf("Credentials %s still exists", rs.Primary.ID)
+			return fmt.Errorf("Credentials still exists: %s - %s", rs.Primary.Attributes["folder"], rs.Primary.Attributes["name"])
 		}
 	}
 

--- a/jenkins/resource_jenkins_credential_username_test.go
+++ b/jenkins/resource_jenkins_credential_username_test.go
@@ -73,7 +73,8 @@ func TestAccJenkinsCredentialUsername_folder(t *testing.T) {
 				}
 
 				resource jenkins_folder foo_sub {
-					name = "${jenkins_folder.foo.name}/subfolder"
+					name = "subfolder"
+					folder = jenkins_folder.foo.id
 					description = "Terraform acceptance testing"
 
 					lifecycle {
@@ -83,12 +84,12 @@ func TestAccJenkinsCredentialUsername_folder(t *testing.T) {
 
 				resource jenkins_credential_username foo {
 				  name = "test-username"
-				  folder = jenkins_folder.foo_sub.name
+				  folder = jenkins_folder.foo_sub.id
 				  username = "foo"
 				  password = "bar"
 				}`, randString),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("jenkins_credential_username.foo", "id", "tf-acc-test-"+randString+"/subfolder/test-username"),
+					resource.TestCheckResourceAttr("jenkins_credential_username.foo", "id", "/job/tf-acc-test-"+randString+"/job/subfolder/test-username"),
 					testAccCheckJenkinsCredentialUsernameExists("jenkins_credential_username.foo", &cred),
 				),
 			},
@@ -105,7 +106,8 @@ func TestAccJenkinsCredentialUsername_folder(t *testing.T) {
 				}
 
 				resource jenkins_folder foo_sub {
-					name = "${jenkins_folder.foo.name}/subfolder"
+					name = "subfolder"
+					folder = jenkins_folder.foo.id
 					description = "Terraform acceptance testing"
 
 					lifecycle {
@@ -115,7 +117,7 @@ func TestAccJenkinsCredentialUsername_folder(t *testing.T) {
 
 				resource jenkins_credential_username foo {
 				  name = "test-username"
-				  folder = jenkins_folder.foo_sub.name
+				  folder = jenkins_folder.foo_sub.id
 				  description = "new-description"
 				  username = "foo"
 				  password = "bar"
@@ -143,7 +145,7 @@ func testAccCheckJenkinsCredentialUsernameExists(resourceName string, cred *jenk
 		}
 
 		manager := client.Credentials()
-		manager.Folder = formatJobName(rs.Primary.Attributes["folder"])
+		manager.Folder = formatFolderName(rs.Primary.Attributes["folder"])
 		err := manager.GetSingle(rs.Primary.Attributes["domain"], rs.Primary.Attributes["name"], cred)
 		if err != nil {
 			return fmt.Errorf("Unable to retrieve credentials for %s - %s: %w", rs.Primary.Attributes["folder"], rs.Primary.Attributes["name"], err)
@@ -163,7 +165,7 @@ func testAccCheckJenkinsCredentialUsernameDestroy(s *terraform.State) error {
 
 		cred := jenkins.UsernameCredentials{}
 		manager := client.Credentials()
-		manager.Folder = formatJobName(rs.Primary.Meta["folder"].(string))
+		manager.Folder = formatFolderName(rs.Primary.Meta["folder"].(string))
 		err := manager.GetSingle(rs.Primary.Meta["domain"].(string), rs.Primary.Meta["name"].(string), &cred)
 		if err == nil {
 			return fmt.Errorf("Credentials still exists: %s - %s", rs.Primary.Attributes["folder"], rs.Primary.Attributes["name"])

--- a/jenkins/resource_jenkins_folder.go
+++ b/jenkins/resource_jenkins_folder.go
@@ -27,10 +27,18 @@ func resourceJenkinsFolder() *schema.Resource {
 		DeleteContext: resourceJenkinsJobDelete,
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:        schema.TypeString,
-				Description: "The unique name of the JenkinsCI folder. Subfolders may be specified as foldername/name.",
-				Required:    true,
-				ForceNew:    true,
+				Type:             schema.TypeString,
+				Description:      "The unique name of the JenkinsCI folder.",
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validateJobName,
+			},
+			"folder": {
+				Type:             schema.TypeString,
+				Description:      "The folder namespace that the folder will be added to as a subfolder.",
+				Optional:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validateFolderName,
 			},
 			"description": {
 				Type:        schema.TypeString,

--- a/jenkins/resource_jenkins_folder_test.go
+++ b/jenkins/resource_jenkins_folder_test.go
@@ -24,6 +24,30 @@ func TestAccJenkinsFolder_basic(t *testing.T) {
 	})
 }
 
+func TestAccJenkinsFolder_nested(t *testing.T) {
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckJenkinsFolderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource jenkins_folder foo {
+					name = "tf-acc-test-%s"
+					description = "Terraform acceptance tests %s"
+				}
+
+				resource jenkins_folder sub {
+					name = "${jenkins_folder.foo.name}/subfolder"
+					description = "Terraform acceptance tests ${jenkins_folder.foo.name}"
+				}`, randString, randString),
+			},
+		},
+	})
+}
+
 func testAccCheckJenkinsFolderDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(jenkinsClient)
 

--- a/jenkins/util.go
+++ b/jenkins/util.go
@@ -7,9 +7,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// formatJobName will format a folder name in the way that Jenkins expects, with "name/job/name" separators.
+// Deduplication will be performed so that it is safe to pass an already-formatted job into this function.
 func formatJobName(name string) string {
 	split := strings.Split(name, "/")
-	return strings.Join(split, "/job/")
+
+	ret := []string{}
+	for _, segment := range split {
+		if segment == "job" {
+			continue
+		}
+		ret = append(ret, segment)
+	}
+	return strings.Join(ret, "/job/")
 }
 
 func parseJobName(name string) (job string, folders []string) {

--- a/jenkins/util_test.go
+++ b/jenkins/util_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestFormatJobName(t *testing.T) {
-	inputSimple, inputFolder, inputNested := "job-name", "folder/job-name", "parent/child/job-name"
+	inputSimple, inputFolder, inputNested, inputDuped := "job-name", "folder/job-name", "parent/child/job-name", "parent/job/child/job/job-name"
 
 	// Simple
 	actual := formatJobName(inputSimple)
@@ -16,13 +16,19 @@ func TestFormatJobName(t *testing.T) {
 	// Folder
 	actual = formatJobName(inputFolder)
 	if actual != "folder/job/job-name" {
-		t.Errorf("Expected %s but received %s", inputSimple, actual)
+		t.Errorf("Expected %s but received %s", inputFolder, actual)
 	}
 
 	// Nested
 	actual = formatJobName(inputNested)
 	if actual != "parent/job/child/job/job-name" {
-		t.Errorf("Expected %s but received %s", inputSimple, actual)
+		t.Errorf("Expected %s but received %s", inputNested, actual)
+	}
+
+	// Deduplicate
+	actual = formatJobName(inputDuped)
+	if actual != "parent/job/child/job/job-name" {
+		t.Errorf("Expected %s but received %s", inputDuped, actual)
 	}
 }
 

--- a/jenkins/util_test.go
+++ b/jenkins/util_test.go
@@ -4,51 +4,51 @@ import (
 	"testing"
 )
 
-func TestFormatJobName(t *testing.T) {
+func TestFormatFolderName(t *testing.T) {
 	inputSimple, inputFolder, inputNested, inputDuped := "job-name", "folder/job-name", "parent/child/job-name", "parent/job/child/job/job-name"
 
 	// Simple
-	actual := formatJobName(inputSimple)
+	actual := formatFolderName(inputSimple)
 	if actual != inputSimple {
 		t.Errorf("Expected %s but received %s", inputSimple, actual)
 	}
 
 	// Folder
-	actual = formatJobName(inputFolder)
+	actual = formatFolderName(inputFolder)
 	if actual != "folder/job/job-name" {
 		t.Errorf("Expected %s but received %s", inputFolder, actual)
 	}
 
 	// Nested
-	actual = formatJobName(inputNested)
+	actual = formatFolderName(inputNested)
 	if actual != "parent/job/child/job/job-name" {
 		t.Errorf("Expected %s but received %s", inputNested, actual)
 	}
 
 	// Deduplicate
-	actual = formatJobName(inputDuped)
+	actual = formatFolderName(inputDuped)
 	if actual != "parent/job/child/job/job-name" {
 		t.Errorf("Expected %s but received %s", inputDuped, actual)
 	}
 }
 
-func TestParseJobName(t *testing.T) {
+func TestParseCanonicalJobID(t *testing.T) {
 	inputSimple, inputFolder, inputNested := "job-name", "folder/job-name", "parent/child/job-name"
 
 	// Simple
-	actual, actualFolders := parseJobName(inputSimple)
+	actual, actualFolders := parseCanonicalJobID(inputSimple)
 	if actual != inputSimple || len(actualFolders) != 0 {
 		t.Errorf("Expected %s with empty folder array but received %s %s", inputSimple, actual, actualFolders)
 	}
 
 	// Folder
-	actual, actualFolders = parseJobName(inputFolder)
+	actual, actualFolders = parseCanonicalJobID(inputFolder)
 	if actual != inputSimple || len(actualFolders) != 1 || actualFolders[0] != "folder" {
 		t.Errorf("Expected %s with single folder array but received %s %s", inputSimple, actual, actualFolders)
 	}
 
 	// Nested
-	actual, actualFolders = parseJobName(inputNested)
+	actual, actualFolders = parseCanonicalJobID(inputNested)
 	if actual != inputSimple || len(actualFolders) != 2 || actualFolders[0] != "parent" || actualFolders[1] != "child" {
 		t.Errorf("Expected %s with double folder array but received %s %s", inputSimple, actual, actualFolders)
 	}

--- a/jenkins/validations.go
+++ b/jenkins/validations.go
@@ -1,0 +1,21 @@
+package jenkins
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+func validateJobName(val interface{}, path cty.Path) diag.Diagnostics {
+	if strings.Contains(val.(string), "/") {
+		return diag.FromErr(fmt.Errorf("Provided name includes path characters. Please use the 'folder' property if specifying a job within a subfolder"))
+	}
+
+	return diag.Diagnostics{}
+}
+
+func validateFolderName(val interface{}, path cty.Path) diag.Diagnostics {
+	return diag.Diagnostics{}
+}


### PR DESCRIPTION
# Breaking Changes

This changes the internal `id` attribute of Jobs and Credentials to closer align with their canonical URLs within Jenkins. When updating to this version you will need to `rm` and `import` any existing Jobs, Folders, or Credentials in your state files in order to update their Ids.

Additionally, this changes how folders are specified in Jobs and Folders. There is now an explicit "Folder" property where you can specify the folder name, or in the case of folders the parent folder(s) name. A validation has been added to the "Name" property that will guide users away from using it for folder structures.

# Dependencies

Comparison PR against #20 

# What Is Changing

A slightly different take on @Otterian's #20 PR (with their commit cherry-picked in to preserve credit). I was having difficulty writing acceptance tests without requiring a `depends_on` check (or a "replace / with /job/" transform) so I tried a different tact of getting `formatJobName()` to support _both_ `folder` properties with "job" in them and without.

Example of how it may have worked without `formatJobName()`:

```tf
resource jenkins_folder foo {
  name = "testing-subfolder"
}

resource jenkins_folder foo2 {
  name = "${jenkins_folder.foo.name}/deeper"
}

resource jenkins_credential_username foo {
  name     = "test-username"
  folder   = replace(jenkins_folder.foo2.name, "/", "/job/")
  username = "foo"
  password = "bar"
}

# OR

resource jenkins_credential_username foo {
  depends_on = [jenkins_folder.foo2]
  name     = "test-username"
  folder   = "testing-subfolder/job/deeper"
  username = "foo"
  password = "bar"
}
```

That method _should_ work with this implementation as well, but this implementation also supports a direct dependency:

```tf
resource jenkins_credential_username foo {
  name     = "test-username"
  folder   = jenkins_folder.foo2.name
  username = "foo"
  password = "bar"
}
```

# Test Steps

```sh
make testacc
```

I'd love @Otterian's opinion on this strategy! I'll admit there was a period in the middle of this where I was ripping my hair out :)