### PR TITLE
Convert Folder to structured type

### DIFF
--- a/docs/data-sources/folder.md
+++ b/docs/data-sources/folder.md
@@ -1,0 +1,28 @@
+# jenkins_folder Data Source
+
+Get the attributes of a folder within Jenkins.
+
+~> The Jenkins installation that uses this resource is expected to have the [Cloudbees Folders Plugin](https://plugins.jenkins.io/cloudbees-folder) installed in their system.
+
+## Example Usage
+
+```hcl
+data jenkins_folder example {
+  name        = "folder-name"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the folder being read.
+* `folder` - (Optional) The folder namespace containing this folder.
+
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `description` - A block of text describing the folder's purpose.
+* `template` - A Jenkins-compatible XML template to describe the folder.

--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -16,6 +16,15 @@ resource jenkins_folder example_child {
   name        = "child-name"
   folder      = jenkins_folder.example.id
   description = "A nested subfolder"
+
+  security {
+    permissions = [
+      "com.cloudbees.plugins.credentials.CredentialsProvider.Create:anonymous",
+      "com.cloudbees.plugins.credentials.CredentialsProvider.Delete:authenticated",
+      "hudson.model.Item.Cancel:authenticated",
+      "hudson.model.Item.Discover:anonymous",
+    ]
+  }
 }
 ```
 

--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -8,12 +8,14 @@ Manages a folder within Jenkins.
 
 ```hcl
 resource jenkins_folder example {
-  name = "folder-name"
+  name        = "folder-name"
+  description = "A top-level folder"
 }
 
 resource jenkins_folder example_child {
-  name   = "child-name"
-  folder = jenkins_folder.example.id
+  name        = "child-name"
+  folder      = jenkins_folder.example.id
+  description = "A nested subfolder"
 }
 ```
 
@@ -24,8 +26,14 @@ The following arguments are supported:
 * `name` - (Required) The name of the folder being created.
 * `folder` - (Optional) The folder namespace to store the subfolder in. If creating in a nested folder structure you may separate folder names with `/`, such as `parent/child`. This name cannot be changed once the folder has been created, and all parent folders must be created in advance.
 * `description` - (Optional) A block of text describing the folder's purpose.
-* `template` - (Optional) A Jenkins-compatible XML template to describe the folder. You can retrieve an existing folder's XML by appending `/config.xml` to its URL and viewing the source in your browser. The `template` property is rendered using a Golang template that takes the other resource arguments as variables. Do not include the XML prolog in the definition. If `template` is not provided this will default to a "best-guess" folder definition.
-* `permissions` - (Optional) A list of strings containing Jenkins permissions assigments to users and groups for the folder. For example:
+* `security` - (Optional) An optional block defining a project-based authorization strategy, documented below.
+
+### security
+
+~> This block may need the [Matrix Authorization Strategy Plugin](https://plugins.jenkins.io/matrix-auth/) installed and enabled in the system's Global Security settings in order to function properly.
+
+* `inheritance_strategy` - The strategy for applying these permissions sets to existing inherited permissions. Defaults to "org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy".
+* `permissions` - A list of strings containing Jenkins permissions assigments to users and groups for the folder. For example:
 
 ```hcl
   permissions = [
@@ -39,4 +47,6 @@ The following arguments are supported:
 
 ## Attribute Reference
 
-All arguments above are exported.
+In addition to all arguments above, the following attributes are exported:
+
+* `template` - A Jenkins-compatible XML template to describe the folder. You can retrieve an existing folder's XML by appending `/config.xml` to its URL and viewing the source in your browser.

--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -59,3 +59,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `template` - A Jenkins-compatible XML template to describe the folder. You can retrieve an existing folder's XML by appending `/config.xml` to its URL and viewing the source in your browser.
+
+## Import
+
+Folders may be imported by their canonical name, e.g.
+
+```sh
+$ terraform import jenkins_folder.example /job/folder-name
+```

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,5 +1,5 @@
 FROM jenkins/jenkins:lts
 
-RUN /usr/local/bin/install-plugins.sh cloudbees-folder pipeline-model-definition git
+RUN /usr/local/bin/install-plugins.sh cloudbees-folder pipeline-model-definition git matrix-auth
 
 HEALTHCHECK --interval=4s --start-period=5s --retries=30 CMD [ "curl", "-f", "http://localhost:8080" ]

--- a/example/folder.tf
+++ b/example/folder.tf
@@ -11,3 +11,9 @@ resource "jenkins_folder" "example" {
     ]
   }
 }
+
+resource "jenkins_folder" "example_subfolder" {
+  name        = "subfolder"
+  folder      = jenkins_folder.example.id
+  description = "A sample subfolder"
+}

--- a/example/folder.tf
+++ b/example/folder.tf
@@ -1,0 +1,13 @@
+resource "jenkins_folder" "example" {
+  name        = "folder-name"
+  description = "A sample folder"
+
+  security {
+    permissions = [
+      "com.cloudbees.plugins.credentials.CredentialsProvider.Create:anonymous",
+      "com.cloudbees.plugins.credentials.CredentialsProvider.Delete:authenticated",
+      "hudson.model.Item.Cancel:authenticated",
+      "hudson.model.Item.Discover:anonymous",
+    ]
+  }
+}

--- a/example/job.tf
+++ b/example/job.tf
@@ -1,6 +1,15 @@
 resource "jenkins_folder" "example" {
   name        = "folder-name"
   description = "A sample folder"
+
+  security {
+    permissions = [
+      "com.cloudbees.plugins.credentials.CredentialsProvider.Create:anonymous",
+      "com.cloudbees.plugins.credentials.CredentialsProvider.Delete:authenticated",
+      "hudson.model.Item.Cancel:authenticated",
+      "hudson.model.Item.Discover:anonymous",
+    ]
+  }
 }
 
 resource "jenkins_job" "pipeline" {

--- a/example/job.tf
+++ b/example/job.tf
@@ -1,17 +1,3 @@
-resource "jenkins_folder" "example" {
-  name        = "folder-name"
-  description = "A sample folder"
-
-  security {
-    permissions = [
-      "com.cloudbees.plugins.credentials.CredentialsProvider.Create:anonymous",
-      "com.cloudbees.plugins.credentials.CredentialsProvider.Delete:authenticated",
-      "hudson.model.Item.Cancel:authenticated",
-      "hudson.model.Item.Discover:anonymous",
-    ]
-  }
-}
-
 resource "jenkins_job" "pipeline" {
   name     = "pipeline"
   folder   = jenkins_folder.example.id

--- a/example/job.tf
+++ b/example/job.tf
@@ -1,25 +1,6 @@
 resource "jenkins_folder" "example" {
   name        = "folder-name"
   description = "A sample folder"
-  template    = <<EOT
-<com.cloudbees.hudson.plugins.folder.Folder plugin="cloudbees-folder@6.6">
-    <actions/>
-    <description>{{ .Description }}</description>
-    <properties>
-    <com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty>
-        <inheritanceStrategy class="org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy"/>
-        {{ range $value := .Permissions }}
-        <permission>{{ $value }}</permission>
-        {{ end }}
-    </com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty>
-    </properties>
-    <icon class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/>
-</com.cloudbees.hudson.plugins.folder.Folder>
-EOT
-
-  lifecycle {
-    ignore_changes = [template]
-  }
 }
 
 resource "jenkins_job" "pipeline" {

--- a/jenkins/data_source_folder.go
+++ b/jenkins/data_source_folder.go
@@ -1,0 +1,68 @@
+package jenkins
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceJenkinsFolder() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceJenkinsFolderRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:             schema.TypeString,
+				Description:      "The unique name of the JenkinsCI folder.",
+				Required:         true,
+				ValidateDiagFunc: validateJobName,
+			},
+			"folder": {
+				Type:             schema.TypeString,
+				Description:      "The folder namespace that the folder exists in.",
+				Optional:         true,
+				ValidateDiagFunc: validateFolderName,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Description: "The description of this folder's purpose.",
+				Computed:    true,
+			},
+			"security": {
+				Type:        schema.TypeSet,
+				Description: "The Jenkins project-based security configuration.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"inheritance_strategy": {
+							Type:        schema.TypeString,
+							Description: "The strategy for applying these permissions sets to existing inherited permissions.",
+							Computed:    true,
+						},
+						"permissions": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The Jenkins permissions sets that provide access to this folder.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+			"template": {
+				Type:        schema.TypeString,
+				Description: "The configuration file template, used to communicate with Jenkins.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceJenkinsFolderRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	name := d.Get("name").(string)
+	folderName := d.Get("folder").(string)
+	d.SetId(formatFolderName(folderName + "/" + name))
+
+	return resourceJenkinsFolderRead(ctx, d, meta)
+}

--- a/jenkins/data_source_jenkins_folder_test.go
+++ b/jenkins/data_source_jenkins_folder_test.go
@@ -1,0 +1,72 @@
+package jenkins
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccJenkinsFolderDataSource_basic(t *testing.T) {
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource jenkins_folder foo {
+				  name = "tf-acc-test-%s"
+				  description = "Terraform acceptance tests %s"
+				}
+
+				data jenkins_folder foo {
+					name = jenkins_folder.foo.name
+				}`, randString, randString),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("jenkins_folder.foo", "id", "/job/tf-acc-test-"+randString),
+					resource.TestCheckResourceAttr("data.jenkins_folder.foo", "id", "/job/tf-acc-test-"+randString),
+					resource.TestCheckResourceAttr("data.jenkins_folder.foo", "name", "tf-acc-test-"+randString),
+					resource.TestCheckResourceAttr("data.jenkins_folder.foo", "description", "Terraform acceptance tests "+randString),
+				),
+			},
+		},
+	})
+}
+
+func TestAccJenkinsFolderDataSource_nested(t *testing.T) {
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource jenkins_folder foo {
+					name = "tf-acc-test-%s"
+				}
+
+				resource jenkins_folder sub {
+					name = "subfolder"
+					folder = jenkins_folder.foo.id
+					description = "Terraform acceptance tests %s"
+				}
+
+				data jenkins_folder sub {
+					name = jenkins_folder.sub.name
+					folder = jenkins_folder.sub.folder
+				}`, randString, randString),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("jenkins_folder.foo", "id", "/job/tf-acc-test-"+randString),
+					resource.TestCheckResourceAttr("jenkins_folder.sub", "id", "/job/tf-acc-test-"+randString+"/job/subfolder"),
+					resource.TestCheckResourceAttr("data.jenkins_folder.sub", "name", "subfolder"),
+					resource.TestCheckResourceAttr("data.jenkins_folder.sub", "folder", "/job/tf-acc-test-"+randString),
+					resource.TestCheckResourceAttr("data.jenkins_folder.sub", "description", "Terraform acceptance tests "+randString),
+				),
+			},
+		},
+	})
+}

--- a/jenkins/folder.go
+++ b/jenkins/folder.go
@@ -1,0 +1,42 @@
+package jenkins
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
+
+type folder struct {
+	XMLName       xml.Name       `xml:"com.cloudbees.hudson.plugins.folder.Folder"`
+	Description   string         `xml:"description"`
+	Properties    xmlRawProperty `xml:"properties"`
+	FolderViews   xmlRawProperty `xml:"folderViews"`
+	HealthMetrics xmlRawProperty `xml:"healthMetrics"`
+}
+
+type xmlRawProperty struct {
+	Raw string `xml:",innerxml"`
+}
+
+func parseFolder(config string) (*folder, error) {
+	ret := &folder{}
+
+	doc := handleXml(config)
+	if err := xml.Unmarshal(doc, &ret); err != nil {
+		return ret, fmt.Errorf("could not parse job XML: %w", err)
+	}
+
+	return ret, nil
+}
+
+func (j *folder) Render() ([]byte, error) {
+	return xml.MarshalIndent(j, "", "\t")
+}
+
+func handleXml(def string) []byte {
+	// This is a horrible practice...but Go doesn't seem to have any mature
+	// support for the XML 1.1 specification. As long as Jenkins doesn't make
+	// use of any 1.1 additions then this should still parse.
+	def = strings.ReplaceAll(def, `<?xml version='1.1' encoding='UTF-8'?>`, `<?xml version='1.0' encoding='UTF-8'?>`)
+	return []byte(def)
+}

--- a/jenkins/folder.go
+++ b/jenkins/folder.go
@@ -7,15 +7,31 @@ import (
 )
 
 type folder struct {
-	XMLName       xml.Name       `xml:"com.cloudbees.hudson.plugins.folder.Folder"`
-	Description   string         `xml:"description"`
-	Properties    xmlRawProperty `xml:"properties"`
-	FolderViews   xmlRawProperty `xml:"folderViews"`
-	HealthMetrics xmlRawProperty `xml:"healthMetrics"`
+	XMLName       xml.Name         `xml:"com.cloudbees.hudson.plugins.folder.Folder"`
+	Description   string           `xml:"description"`
+	Properties    folderProperties `xml:"properties"`
+	FolderViews   xmlRawProperty   `xml:"folderViews"`
+	HealthMetrics xmlRawProperty   `xml:"healthMetrics"`
+}
+
+type folderProperties struct {
+	Security *folderSecurity  `xml:"com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty,omitempty"`
+	Other    []xmlRawProperty `xml:",any"`
+}
+
+type folderSecurity struct {
+	InheritanceStrategy folderPermissionInheritanceStrategy `xml:"inheritanceStrategy"`
+	Permission          []string                            `xml:"permission"`
+}
+
+type folderPermissionInheritanceStrategy struct {
+	Class string `xml:"class,attr"`
 }
 
 type xmlRawProperty struct {
-	Raw string `xml:",innerxml"`
+	XMLName xml.Name
+	Plugin  string `xml:"plugin,attr,omitempty"`
+	Raw     string `xml:",innerxml"`
 }
 
 func parseFolder(config string) (*folder, error) {

--- a/jenkins/folder_test.go
+++ b/jenkins/folder_test.go
@@ -1,0 +1,214 @@
+package jenkins
+
+import (
+	"encoding/xml"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func Test_parseFolder(t *testing.T) {
+	type args struct {
+		def string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *folder
+		wantErr bool
+	}{
+		{
+			name: "success",
+			args: args{
+				def: `<com.cloudbees.hudson.plugins.folder.Folder plugin="cloudbees-folder@6.15">
+  <actions/>
+  <description>Example Description</description>
+  <properties>
+    <org.jenkinsci.plugins.workflow.libs.FolderLibraries plugin="workflow-cps-global-lib@2.17">
+      <libraries>
+        <org.jenkinsci.plugins.workflow.libs.LibraryConfiguration>
+          <name>Example Library Configuration</name>
+          <implicit>false</implicit>
+          <allowVersionOverride>true</allowVersionOverride>
+          <includeInChangesets>true</includeInChangesets>
+        </org.jenkinsci.plugins.workflow.libs.LibraryConfiguration>
+      </libraries>
+    </org.jenkinsci.plugins.workflow.libs.FolderLibraries>
+  </properties>
+  <folderViews class="com.cloudbees.hudson.plugins.folder.views.DefaultFolderViewHolder">
+    <views>
+      <hudson.model.AllView>
+        <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../../.."/>
+        <name>All</name>
+        <filterExecutors>false</filterExecutors>
+        <filterQueue>false</filterQueue>
+        <properties class="hudson.model.View$PropertyList"/>
+      </hudson.model.AllView>
+      <hudson.model.ListView>
+        <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../../.."/>
+        <name>Example View</name>
+        <filterExecutors>false</filterExecutors>
+        <filterQueue>false</filterQueue>
+        <properties class="hudson.model.View$PropertyList"/>
+        <jobNames>
+          <comparator class="hudson.util.CaseInsensitiveComparator"/>
+        </jobNames>
+        <jobFilters/>
+        <columns>
+          <hudson.views.StatusColumn/>
+          <hudson.views.WeatherColumn/>
+          <hudson.views.JobColumn/>
+          <hudson.views.LastSuccessColumn/>
+          <hudson.views.LastFailureColumn/>
+          <hudson.views.LastDurationColumn/>
+          <hudson.views.BuildButtonColumn/>
+        </columns>
+        <recurse>false</recurse>
+      </hudson.model.ListView>
+    </views>
+    <primaryView>All</primaryView>
+    <tabBar class="hudson.views.DefaultViewsTabBar"/>
+  </folderViews>
+  <healthMetrics>
+    <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+      <nonRecursive>true</nonRecursive>
+    </com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+  </healthMetrics>
+  <icon class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/>
+</com.cloudbees.hudson.plugins.folder.Folder>`,
+			},
+			want: &folder{
+				XMLName:     xml.Name{Local: "com.cloudbees.hudson.plugins.folder.Folder"},
+				Description: "Example Description",
+				Properties: xmlRawProperty{Raw: `
+    <org.jenkinsci.plugins.workflow.libs.FolderLibraries plugin="workflow-cps-global-lib@2.17">
+      <libraries>
+        <org.jenkinsci.plugins.workflow.libs.LibraryConfiguration>
+          <name>Example Library Configuration</name>
+          <implicit>false</implicit>
+          <allowVersionOverride>true</allowVersionOverride>
+          <includeInChangesets>true</includeInChangesets>
+        </org.jenkinsci.plugins.workflow.libs.LibraryConfiguration>
+      </libraries>
+    </org.jenkinsci.plugins.workflow.libs.FolderLibraries>
+  `},
+				FolderViews: xmlRawProperty{Raw: `
+    <views>
+      <hudson.model.AllView>
+        <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../../.."/>
+        <name>All</name>
+        <filterExecutors>false</filterExecutors>
+        <filterQueue>false</filterQueue>
+        <properties class="hudson.model.View$PropertyList"/>
+      </hudson.model.AllView>
+      <hudson.model.ListView>
+        <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../../.."/>
+        <name>Example View</name>
+        <filterExecutors>false</filterExecutors>
+        <filterQueue>false</filterQueue>
+        <properties class="hudson.model.View$PropertyList"/>
+        <jobNames>
+          <comparator class="hudson.util.CaseInsensitiveComparator"/>
+        </jobNames>
+        <jobFilters/>
+        <columns>
+          <hudson.views.StatusColumn/>
+          <hudson.views.WeatherColumn/>
+          <hudson.views.JobColumn/>
+          <hudson.views.LastSuccessColumn/>
+          <hudson.views.LastFailureColumn/>
+          <hudson.views.LastDurationColumn/>
+          <hudson.views.BuildButtonColumn/>
+        </columns>
+        <recurse>false</recurse>
+      </hudson.model.ListView>
+    </views>
+    <primaryView>All</primaryView>
+    <tabBar class="hudson.views.DefaultViewsTabBar"/>
+  `},
+				HealthMetrics: xmlRawProperty{Raw: `
+    <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+      <nonRecursive>true</nonRecursive>
+    </com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+  `},
+			},
+		},
+		{
+			name: "error-invalid-xml",
+			args: args{
+				def: `Invalid`,
+			},
+			want:    &folder{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseFolder(tt.args.def)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseFolder() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseFolder() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_folder_Render(t *testing.T) {
+	type fields struct {
+		Description string
+		Properties  string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "success",
+			fields: fields{
+				Description: "Example Description",
+				Properties: `<com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty>
+					<permission>example</permission>
+					<permission>permission</permission>
+				</com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty>`,
+			},
+			want: []byte(`<com.cloudbees.hudson.plugins.folder.Folder>
+	<description>Example Description</description>
+	<properties>
+		<com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty>
+			<permission>example</permission>
+			<permission>permission</permission>
+		</com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty>
+	</properties>
+	<folderViews></folderViews>
+	<healthMetrics></healthMetrics>
+</com.cloudbees.hudson.plugins.folder.Folder>`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j := &folder{
+				Description: tt.fields.Description,
+				Properties:  xmlRawProperty{Raw: tt.fields.Properties},
+			}
+			got, err := j.Render()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("folder.Render() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			strGot := strings.ReplaceAll(string(got), "\n", "")
+			strGot = strings.ReplaceAll(strGot, "\t", "")
+			want := strings.ReplaceAll(string(tt.want), "\n", "")
+			want = strings.ReplaceAll(want, "\t", "")
+
+			if strGot != want {
+				t.Errorf("folder.Render() = %v, want %v", strGot, want)
+			}
+		})
+	}
+}

--- a/jenkins/provider.go
+++ b/jenkins/provider.go
@@ -38,6 +38,10 @@ func Provider() *schema.Provider {
 			},
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"jenkins_folder": dataSourceJenkinsFolder(),
+		},
+
 		ResourcesMap: map[string]*schema.Resource{
 			"jenkins_credential_username":      resourceJenkinsCredentialUsername(),
 			"jenkins_credential_vault_approle": resourceJenkinsCredentialVaultAppRole(),

--- a/jenkins/resource_jenkins_folder.go
+++ b/jenkins/resource_jenkins_folder.go
@@ -1,29 +1,20 @@
 package jenkins
 
 import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-const resourceJenkinsFolderTmpl = `<com.cloudbees.hudson.plugins.folder.Folder plugin="cloudbees-folder@6.6">
-  <actions/>
-  <description>{{ .Description }}</description>
-  <properties>
-    <com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty>
-      <inheritanceStrategy class="org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy"/>
-      {{ range $value := .Permissions }}
-      <permission>{{ $value }}</permission>
-      {{ end }}
-    </com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty>
-  </properties>
-  <icon class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/>
-</com.cloudbees.hudson.plugins.folder.Folder>
-`
-
 func resourceJenkinsFolder() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceJenkinsJobCreate,
-		ReadContext:   resourceJenkinsJobRead,
-		UpdateContext: resourceJenkinsJobUpdate,
+		CreateContext: resourceJenkinsFolderCreate,
+		ReadContext:   resourceJenkinsFolderRead,
+		UpdateContext: resourceJenkinsFolderUpdate,
 		DeleteContext: resourceJenkinsJobDelete,
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -45,21 +36,124 @@ func resourceJenkinsFolder() *schema.Resource {
 				Description: "The description of this folder's purpose.",
 				Optional:    true,
 			},
-			"permissions": {
-				Type:        schema.TypeSet,
-				Description: "The Jenkins permissions sets that provide additional access to this folder.",
-				Optional:    true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
 			"template": {
-				Type:             schema.TypeString,
-				Description:      "The configuration file template, used to communicate with Jenkins.",
-				Optional:         true,
-				Default:          resourceJenkinsFolderTmpl,
-				DiffSuppressFunc: templateDiff,
+				Type:        schema.TypeString,
+				Description: "The configuration file template, used to communicate with Jenkins.",
+				Computed:    true,
 			},
 		},
 	}
+}
+
+func resourceJenkinsFolderCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(jenkinsClient)
+	name := d.Get("name").(string)
+	folderName := formatFolderName(d.Get("folder").(string))
+
+	// Validate that the folder exists
+	if err := folderExists(client, folderName); err != nil {
+		return diag.FromErr(fmt.Errorf("jenkins::create - Could not find folder '%s': %w", folderName, err))
+	}
+
+	f := folder{
+		Description: d.Get("description").(string),
+	}
+
+	xml, err := f.Render()
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("jenkins::create - Error binding config.xml template to %q: %w", name, err))
+	}
+
+	folders := extractFolders(folderName)
+	_, err = client.CreateJobInFolder(string(xml), name, folders...)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("jenkins::create - Error creating job for %q in folder %s: %w", name, folderName, err))
+	}
+
+	log.Printf("[DEBUG] jenkins::create - job %q created in folder %s", name, folderName)
+	d.SetId(formatFolderName(folderName + "/" + name))
+
+	return resourceJenkinsFolderRead(ctx, d, meta)
+}
+
+func resourceJenkinsFolderRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(jenkinsClient)
+	name, folders := parseCanonicalJobID(d.Id())
+
+	log.Printf("[DEBUG] jenkins::read - Looking for job %q", name)
+
+	job, err := client.GetJob(name, folders...)
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "404") {
+			// Job does not exist
+			d.SetId("")
+			return nil
+		}
+
+		return diag.FromErr(fmt.Errorf("jenkins::read - Job %q does not exist: %w", name, err))
+	}
+
+	// Extract the raw XML configuration
+	config, err := job.GetConfig()
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("jenkins::read - Job %q could not extract configuration: %v", job.Base, err))
+	}
+
+	log.Printf("[DEBUG] jenkins::read - Job %q exists", job.Base)
+	d.SetId(job.Base)
+
+	if err := d.Set("template", config); err != nil {
+		return diag.FromErr(err)
+	}
+
+	// Next, parse the properties from the config
+	f, err := parseFolder(config)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("description", f.Description); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceJenkinsFolderUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(jenkinsClient)
+	name, folders := parseCanonicalJobID(d.Id())
+
+	// grab job by current name
+	job, err := client.GetJob(name, folders...)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("jenkins::update - Could not find job %q: %w", name, err))
+	}
+
+	// Extract the raw XML configuration
+	config, err := job.GetConfig()
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("jenkins::update - Job %q could not extract configuration: %v", job.Base, err))
+	}
+
+	// Next, parse the properties from the config
+	f, err := parseFolder(config)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// Then update the values
+	f.Description = d.Get("description").(string)
+
+	// And send it back to Jenkins
+	xml, err := f.Render()
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("jenkins::create - Error binding config.xml template to %q: %w", name, err))
+	}
+
+	err = job.UpdateConfig(string(xml))
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("jenkins::update - Error updating job %q configuration: %w", name, err))
+	}
+
+	return resourceJenkinsFolderRead(ctx, d, meta)
 }

--- a/jenkins/resource_jenkins_folder.go
+++ b/jenkins/resource_jenkins_folder.go
@@ -16,6 +16,9 @@ func resourceJenkinsFolder() *schema.Resource {
 		ReadContext:   resourceJenkinsFolderRead,
 		UpdateContext: resourceJenkinsFolderUpdate,
 		DeleteContext: resourceJenkinsJobDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:             schema.TypeString,
@@ -71,7 +74,7 @@ func resourceJenkinsFolder() *schema.Resource {
 func resourceJenkinsFolderCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(jenkinsClient)
 	name := d.Get("name").(string)
-	folderName := formatFolderName(d.Get("folder").(string))
+	folderName := d.Get("folder").(string)
 
 	// Validate that the folder exists
 	if err := folderExists(client, folderName); err != nil {
@@ -133,6 +136,14 @@ func resourceJenkinsFolderRead(ctx context.Context, d *schema.ResourceData, meta
 	// Next, parse the properties from the config
 	f, err := parseFolder(config)
 	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("name", name); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("folder", formatFolderID(folders)); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/jenkins/template_test.go
+++ b/jenkins/template_test.go
@@ -48,56 +48,9 @@ func TestRenderTemplate(t *testing.T) {
 	}
 }
 
-func TestRenderTemplateFolder(t *testing.T) {
-	// Set up inputs
-	input := "<root>Test {{ .Description }}</root>"
-	expected := "<root>Test Case</root>"
-
-	// Set up Job
-	job := resourceJenkinsFolder()
-	d := job.TestResourceData()
-	d.Set("name", "Test Name")
-	d.Set("description", "Case")
-	d.Set("permissions", []string{"Test Permission"})
-
-	// Test simple
-	if actual, err := renderTemplate(input, d); err != nil {
-		t.Fatal(err)
-	} else if actual != expected {
-		t.Errorf("Expected %s to be considered equal to %s", actual, expected)
-	}
-
-	// Now with a fully populated template
-	input = `<root>
-	<name>{{ .Name }}</name>
-	<description>{{ .Description }}</description>
-	<permissions>
-		{{ range $value := .Permissions -}}
-		<permission>{{ $value }}</permission>
-		{{- end }}
-	</permissions>
-</root>
-`
-
-	expected = `<root>
-	<name>Test Name</name>
-	<description>Case</description>
-	<permissions>
-		<permission>Test Permission</permission>
-	</permissions>
-</root>
-`
-
-	if actual, err := renderTemplate(input, d); err != nil {
-		t.Fatal(err)
-	} else if actual != expected {
-		t.Errorf("Expected %s to be considered equal to %s", actual, expected)
-	}
-}
-
 func TestRenderTemplateInvalid(t *testing.T) {
 	// Set up Job
-	job := resourceJenkinsFolder()
+	job := resourceJenkinsJob()
 	d := job.TestResourceData()
 	d.Set("name", "Test Name")
 

--- a/jenkins/util.go
+++ b/jenkins/util.go
@@ -22,6 +22,14 @@ func formatFolderName(name string) string {
 	return strings.Join(ret, "/job/")
 }
 
+// formatFolderID will format a set of folders in the way that Jenkins expects for the "folder" property, with "/job/name/job/name" separators.
+func formatFolderID(folders []string) string {
+	if len(folders) == 0 {
+		return ""
+	}
+	return "/job/" + formatFolderName(strings.Join(folders, "/"))
+}
+
 // extractFolders prepares a job name for some folder-aware client library calls.
 // These calls are different from other calls in that they expect the folders to be specified
 // as a series of parameters with no "/job/" separators.

--- a/jenkins/util_test.go
+++ b/jenkins/util_test.go
@@ -32,6 +32,30 @@ func TestFormatFolderName(t *testing.T) {
 	}
 }
 
+func TestFormatFolderID(t *testing.T) {
+	inputSimple := []string{"folder-id"}
+	inputNested := []string{"folder-parent", "folder-id"}
+	inputDuped := []string{"folder-parent", "job", "folder-id"}
+
+	// Simple
+	actual := formatFolderID(inputSimple)
+	if actual != "/job/folder-id" {
+		t.Errorf("Expected /job/folder-id but received %s", actual)
+	}
+
+	// Nested
+	actual = formatFolderID(inputNested)
+	if actual != "/job/folder-parent/job/folder-id" {
+		t.Errorf("Expected /job/folder-parent/job/folder-id but received %s", actual)
+	}
+
+	// Deduplicate
+	actual = formatFolderID(inputDuped)
+	if actual != "/job/folder-parent/job/folder-id" {
+		t.Errorf("Expected /job/folder-parent/job/folder-id but received %s", actual)
+	}
+}
+
 func TestParseCanonicalJobID(t *testing.T) {
 	inputSimple, inputFolder, inputNested := "job-name", "folder/job-name", "parent/child/job-name"
 


### PR DESCRIPTION
# Dependencies

Backwards incompatible change for the `folder` resource type. The resource now no longer allows direct modification of the `template` property and instead computes it based off the parsed XML from Jenkins.

# What Is Changing

Converting the Folder resource into a "structured" type. This means that it will no longer allow the `template` to be defined explicitly and instead only allows modification of the managed properties.

Adding import support for Folders.

Adding a data source for Folders.

# Test Steps

```sh
make testacc
```

<!-- Additional test steps beyond the acceptance tests go here. -->
