### PR TITLE
New resource credential_secret_text

### DIFF
--- a/docs/resources/credential_secret_text.md
+++ b/docs/resources/credential_secret_text.md
@@ -1,0 +1,27 @@
+# jenkins_credential_secret_text Resource
+
+Manages a secret text credential within Jenkins. This secret text may then be referenced within jobs that are created.
+
+## Example Usage
+
+```hcl
+resource "jenkins_credential_secret_text" "example" {
+  name     = "example-username"
+  secret   = "super-secret"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the credentials being created. This maps to the ID property within Jenkins, and cannot be changed once set.
+* `domain` - (Optional) The domain store to place the credentials into. If not set will default to the global credentials store.
+* `folder` - (Optional) The folder namespace to store the credentials in. If not set will default to global Jenkins credentials.
+* `scope` - (Optional) The visibility of the credentials to Jenkins agents. This must be set to either "GLOBAL" or "SYSTEM". If not set will default to "GLOBAL".
+* `description` - (Optional) A human readable description of the credentials being stored.
+* `secret` - (Required) The secret text to be associated with the credentials.
+
+## Attribute Reference
+
+All arguments above are exported.

--- a/example/credentials_secret_text.tf
+++ b/example/credentials_secret_text.tf
@@ -1,0 +1,10 @@
+resource "jenkins_credential_secret_text" "global" {
+  name   = "global-username"
+  secret = "barsoom"
+}
+
+resource "jenkins_credential_secret_text" "folder" {
+  name   = "folder-username"
+  folder = jenkins_folder.example.id
+  secret = "barsoom"
+}

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3.7'
 
 services:
   jenkins:

--- a/jenkins/provider.go
+++ b/jenkins/provider.go
@@ -46,6 +46,7 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"jenkins_credential_secret_text":   resourceJenkinsCredentialSecretText(),
 			"jenkins_credential_username":      resourceJenkinsCredentialUsername(),
 			"jenkins_credential_vault_approle": resourceJenkinsCredentialVaultAppRole(),
 			"jenkins_folder":                   resourceJenkinsFolder(),

--- a/jenkins/resource_jenkins_credential_secret_text.go
+++ b/jenkins/resource_jenkins_credential_secret_text.go
@@ -83,7 +83,7 @@ func resourceJenkinsCredentialSecretTextCreate(ctx context.Context, d *schema.Re
 	domain := d.Get("domain").(string)
 	err := cm.Add(domain, cred)
 	if err != nil {
-		return diag.Errorf("Could not create username credentials: %s", err)
+		return diag.Errorf("Could not create secret text credentials: %s", err)
 	}
 
 	d.SetId(generateCredentialID(d.Get("folder").(string), cred.ID))

--- a/jenkins/resource_jenkins_credential_secret_text.go
+++ b/jenkins/resource_jenkins_credential_secret_text.go
@@ -55,7 +55,7 @@ func resourceJenkinsCredentialSecretText() *schema.Resource {
 			},
 			"secret": {
 				Type:        schema.TypeString,
-				Description: "The credentias secret tect. This is mandatory.",
+				Description: "The credentials secret text. This is mandatory.",
 				Required:    true,
 				Sensitive:   true,
 			},

--- a/jenkins/resource_jenkins_credential_secret_text.go
+++ b/jenkins/resource_jenkins_credential_secret_text.go
@@ -108,7 +108,7 @@ func resourceJenkinsCredentialSecretTextRead(ctx context.Context, d *schema.Reso
 			return nil
 		}
 
-		return diag.Errorf("Could not read username credentials: %s", err)
+		return diag.Errorf("Could not read secret text credentials: %s", err)
 	}
 
 	d.SetId(generateCredentialID(d.Get("folder").(string), cred.ID))

--- a/jenkins/resource_jenkins_credential_secret_text.go
+++ b/jenkins/resource_jenkins_credential_secret_text.go
@@ -10,14 +10,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func resourceJenkinsCredentialUsername() *schema.Resource {
+func resourceJenkinsCredentialSecretText() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceJenkinsCredentialUsernameCreate,
-		ReadContext:   resourceJenkinsCredentialUsernameRead,
-		UpdateContext: resourceJenkinsCredentialUsernameUpdate,
-		DeleteContext: resourceJenkinsCredentialUsernameDelete,
+		CreateContext: resourceJenkinsCredentialSecretTextCreate,
+		ReadContext:   resourceJenkinsCredentialSecretTextRead,
+		UpdateContext: resourceJenkinsCredentialSecretTextUpdate,
+		DeleteContext: resourceJenkinsCredentialSecretTextDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceJenkinsCredentialUsernameImport,
+			StateContext: resourceJenkinsCredentialSecretTextImport,
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -53,22 +53,17 @@ func resourceJenkinsCredentialUsername() *schema.Resource {
 				Optional:    true,
 				Default:     "Managed by Terraform",
 			},
-			"username": {
+			"secret": {
 				Type:        schema.TypeString,
-				Description: "The credentials user username.",
+				Description: "The credentias secret tect. This is mandatory.",
 				Required:    true,
-			},
-			"password": {
-				Type:        schema.TypeString,
-				Description: "The credentials user password. If left empty will be unmanaged.",
-				Optional:    true,
 				Sensitive:   true,
 			},
 		},
 	}
 }
 
-func resourceJenkinsCredentialUsernameCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJenkinsCredentialSecretTextCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(jenkinsClient)
 	cm := client.Credentials()
 	cm.Folder = formatFolderName(d.Get("folder").(string))
@@ -78,12 +73,11 @@ func resourceJenkinsCredentialUsernameCreate(ctx context.Context, d *schema.Reso
 		return diag.FromErr(fmt.Errorf("invalid folder name '%s' specified: %w", cm.Folder, err))
 	}
 
-	cred := jenkins.UsernameCredentials{
+	cred := jenkins.StringCredentials{
 		ID:          d.Get("name").(string),
 		Scope:       d.Get("scope").(string),
 		Description: d.Get("description").(string),
-		Username:    d.Get("username").(string),
-		Password:    d.Get("password").(string),
+		Secret:      d.Get("secret").(string),
 	}
 
 	domain := d.Get("domain").(string)
@@ -93,14 +87,14 @@ func resourceJenkinsCredentialUsernameCreate(ctx context.Context, d *schema.Reso
 	}
 
 	d.SetId(generateCredentialID(d.Get("folder").(string), cred.ID))
-	return resourceJenkinsCredentialUsernameRead(ctx, d, meta)
+	return resourceJenkinsCredentialSecretTextRead(ctx, d, meta)
 }
 
-func resourceJenkinsCredentialUsernameRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJenkinsCredentialSecretTextRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cm := meta.(jenkinsClient).Credentials()
 	cm.Folder = formatFolderName(d.Get("folder").(string))
 
-	cred := jenkins.UsernameCredentials{}
+	cred := jenkins.StringCredentials{}
 	err := cm.GetSingle(
 		d.Get("domain").(string),
 		d.Get("name").(string),
@@ -120,40 +114,34 @@ func resourceJenkinsCredentialUsernameRead(ctx context.Context, d *schema.Resour
 	d.SetId(generateCredentialID(d.Get("folder").(string), cred.ID))
 	d.Set("scope", cred.Scope)
 	d.Set("description", cred.Description)
-	d.Set("username", cred.Username)
-	// NOTE: We are NOT setting the password here, as the password returned by GetSingle is garbage
-	// Password only applies to Create/Update operations if the "password" property is non-empty
+	// NOTE: We are NOT setting the secret here, as the secret returned by GetSingle is garbage
+	// Secret only applies to Create/Update operations if the "password" property is non-empty
 
 	return nil
 }
 
-func resourceJenkinsCredentialUsernameUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJenkinsCredentialSecretTextUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cm := meta.(jenkinsClient).Credentials()
 	cm.Folder = formatFolderName(d.Get("folder").(string))
 
 	domain := d.Get("domain").(string)
-	cred := jenkins.UsernameCredentials{
+	cred := jenkins.StringCredentials{
 		ID:          d.Get("name").(string),
 		Scope:       d.Get("scope").(string),
 		Description: d.Get("description").(string),
-		Username:    d.Get("username").(string),
-	}
-
-	// Only enforce the password if it is non-empty
-	if d.Get("password").(string) != "" {
-		cred.Password = d.Get("password").(string)
+		Secret:      d.Get("secret").(string),
 	}
 
 	err := cm.Update(domain, d.Get("name").(string), &cred)
 	if err != nil {
-		return diag.Errorf("Could not update username credentials: %s", err)
+		return diag.Errorf("Could not update secret text: %s", err)
 	}
 
 	d.SetId(generateCredentialID(d.Get("folder").(string), cred.ID))
-	return resourceJenkinsCredentialUsernameRead(ctx, d, meta)
+	return resourceJenkinsCredentialSecretTextRead(ctx, d, meta)
 }
 
-func resourceJenkinsCredentialUsernameDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJenkinsCredentialSecretTextDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cm := meta.(jenkinsClient).Credentials()
 	cm.Folder = formatFolderName(d.Get("folder").(string))
 
@@ -168,7 +156,7 @@ func resourceJenkinsCredentialUsernameDelete(ctx context.Context, d *schema.Reso
 	return nil
 }
 
-func resourceJenkinsCredentialUsernameImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceJenkinsCredentialSecretTextImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 	ret := []*schema.ResourceData{d}
 
 	splitID := strings.Split(d.Id(), "/")

--- a/jenkins/resource_jenkins_credential_secret_text_test.go
+++ b/jenkins/resource_jenkins_credential_secret_text_test.go
@@ -1,0 +1,165 @@
+package jenkins
+
+import (
+	"fmt"
+	"testing"
+
+	jenkins "github.com/bndr/gojenkins"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccJenkinsCredentialSecretText_basic(t *testing.T) {
+	var cred jenkins.StringCredentials
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckJenkinsCredentialSecretTextDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource jenkins_credential_secret_text foo {
+				  name = "test-secret-text"
+				  secret = "very-secret"
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("jenkins_credential_secret_text.foo", "id", "/test-secret-text"),
+					testAccCheckJenkinsCredentialSecretTextExists("jenkins_credential_secret_text.foo", &cred),
+				),
+			},
+			{
+				// Update by adding description
+				Config: `
+				resource jenkins_credential_secret_text foo {
+				  name = "test-secret-text"
+				  description = "new-description"
+				  secret = "very-secret"
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckJenkinsCredentialSecretTextExists("jenkins_credential_secret_text.foo", &cred),
+					resource.TestCheckResourceAttr("jenkins_credential_secret_text.foo", "description", "new-description"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccJenkinsCredentialSecretText_folder(t *testing.T) {
+	var cred jenkins.StringCredentials
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckJenkinsCredentialSecretTextDestroy,
+			testAccCheckJenkinsFolderDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource jenkins_folder foo {
+					name = "tf-acc-test-%s"
+					description = "Terraform acceptance testing"
+				}
+
+				resource jenkins_folder foo_sub {
+					name = "subfolder"
+					folder = jenkins_folder.foo.id
+					description = "Terraform acceptance testing"
+				}
+
+				resource jenkins_credential_secret_text foo {
+				  name = "test-secret-text"
+				  folder = jenkins_folder.foo_sub.id
+				  secret = "very-secret"
+				}`, randString),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("jenkins_credential_secret_text.foo", "id", "/job/tf-acc-test-"+randString+"/job/subfolder/test-secret-text"),
+					testAccCheckJenkinsCredentialSecretTextExists("jenkins_credential_secret_text.foo", &cred),
+				),
+			},
+			{
+				// Update by adding description
+				Config: fmt.Sprintf(`
+				resource jenkins_folder foo {
+					name = "tf-acc-test-%s"
+					description = "Terraform acceptance testing"
+
+					lifecycle {
+						ignore_changes = [template]
+					}
+				}
+
+				resource jenkins_folder foo_sub {
+					name = "subfolder"
+					folder = jenkins_folder.foo.id
+					description = "Terraform acceptance testing"
+
+					lifecycle {
+						ignore_changes = [template]
+					}
+				}
+
+				resource jenkins_credential_secret_text foo {
+				  name = "test-secret-text"
+				  folder = jenkins_folder.foo_sub.id
+				  description = "new-description"
+				  secret = "very-secret"
+				}`, randString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckJenkinsCredentialSecretTextExists("jenkins_credential_secret_text.foo", &cred),
+					resource.TestCheckResourceAttr("jenkins_credential_secret_text.foo", "description", "new-description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckJenkinsCredentialSecretTextExists(resourceName string, cred *jenkins.StringCredentials) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(jenkinsClient)
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf(resourceName + " not found")
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("ID is not set")
+		}
+
+		manager := client.Credentials()
+		manager.Folder = formatFolderName(rs.Primary.Attributes["folder"])
+		err := manager.GetSingle(rs.Primary.Attributes["domain"], rs.Primary.Attributes["name"], cred)
+		if err != nil {
+			return fmt.Errorf("Unable to retrieve credentials for %s - %s: %w", rs.Primary.Attributes["folder"], rs.Primary.Attributes["name"], err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckJenkinsCredentialSecretTextDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(jenkinsClient)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "jenkins_credential_secret_text" {
+			continue
+		} else if _, ok := rs.Primary.Meta["name"]; !ok {
+			continue
+		}
+
+		cred := jenkins.StringCredentials{}
+		manager := client.Credentials()
+		manager.Folder = formatFolderName(rs.Primary.Meta["folder"].(string))
+		err := manager.GetSingle(rs.Primary.Meta["domain"].(string), rs.Primary.Meta["name"].(string), &cred)
+		if err == nil {
+			return fmt.Errorf("Credentials still exists: %s - %s", rs.Primary.Attributes["folder"], rs.Primary.Attributes["name"])
+		}
+	}
+
+	return nil
+}

--- a/jenkins/util.go
+++ b/jenkins/util.go
@@ -1,6 +1,7 @@
 package jenkins
 
 import (
+	"fmt"
 	"log"
 	"strings"
 
@@ -86,4 +87,8 @@ func templateDiff(k, old, new string, d *schema.ResourceData) bool {
 	log.Printf("[DEBUG] jenkins::diff - Old: %q", old)
 	log.Printf("[DEBUG] jenkins::diff - New: %q", new)
 	return old == new
+}
+
+func generateCredentialID(folder, name string) string {
+	return fmt.Sprintf("%s/%s", folder, name)
 }

--- a/jenkins/util_test.go
+++ b/jenkins/util_test.go
@@ -108,3 +108,11 @@ func TestTemplateDiff(t *testing.T) {
 		t.Errorf("Expected %s to be considered inequal to %s", inputLeft, inputRight)
 	}
 }
+
+func TestGenerateCredentialID(t *testing.T) {
+	inputFolder, inputName := "test-folder", "test-name"
+	actual := generateCredentialID(inputFolder, inputName)
+	if actual != "test-folder/test-name" {
+		t.Errorf("Expected %s/%s but got: %s", inputFolder, inputName, actual)
+	}
+}

--- a/jenkins/validations.go
+++ b/jenkins/validations.go
@@ -19,3 +19,13 @@ func validateJobName(val interface{}, path cty.Path) diag.Diagnostics {
 func validateFolderName(val interface{}, path cty.Path) diag.Diagnostics {
 	return diag.Diagnostics{}
 }
+
+func validateCredentialScope(val interface{}, path cty.Path) diag.Diagnostics {
+	var supportedCredentialScopes = []string{"SYSTEM", "GLOBAL"}
+	for _, supported := range supportedCredentialScopes {
+		if val == supported {
+			return diag.Diagnostics{}
+		}
+	}
+	return diag.Errorf("Invalid scope: %s. Supported scopes are: %s", val, strings.Join(supportedCredentialScopes, ", "))
+}

--- a/jenkins/validations_test.go
+++ b/jenkins/validations_test.go
@@ -1,0 +1,56 @@
+package jenkins
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+)
+
+func TestValidateJobName(t *testing.T) {
+
+	input, ctyPath := "job_name", make(cty.Path, 0)
+	actual := validateJobName(input, ctyPath)
+
+	if actual.HasError() {
+		t.Errorf("Error, validation failed for input: %s", input)
+	}
+
+	// Test if we fail when we should
+	input = "job_name/second_level"
+	actual = validateCredentialScope(input, ctyPath)
+	if !actual.HasError() {
+		t.Errorf("Error, validation failed for input: %s", input)
+	}
+}
+
+func TestValidateFolderName(t *testing.T) {
+
+	input, ctyPath := "folder_name", make(cty.Path, 0)
+	actual := validateFolderName(input, ctyPath)
+
+	if actual.HasError() {
+		t.Errorf("Error, validation failed for input: %s", input)
+	}
+}
+
+func TestValidateCredentialScope(t *testing.T) {
+
+	input, ctyPath := "GLOBAL", make(cty.Path, 0)
+	actual := validateCredentialScope(input, ctyPath)
+	if actual.HasError() {
+		t.Errorf("Error, validation failed for input: %s", input)
+	}
+
+	input = "SYSTEM"
+	actual = validateCredentialScope(input, ctyPath)
+	if actual.HasError() {
+		t.Errorf("Error, validation failed for input: %s", input)
+	}
+
+	// Test if we fail when we should
+	input = "WRONG_INPUT"
+	actual = validateCredentialScope(input, ctyPath)
+	if !actual.HasError() {
+		t.Errorf("Error, negative validation failed for input: %s", input)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Jacek Kikiewicz <public@kikiewicz.com>

# Dependencies

No changes.

# What Is Changing

Added new resource allowing addition / management for credential secret text

# Test Steps

```sh
make test
make testacc
```

<!-- Additional test steps beyond the acceptance tests go here. -->

Also, I made some things common as they are identical for credentials_username and credentials_secret_text, additionaly I updated doc to reflect this.

This seems to be resolving: https://github.com/taiidani/terraform-provider-jenkins/issues/35
