### PR TITLE
Refresh Documentation

### DIFF
--- a/docs/data-sources/credential_username.md
+++ b/docs/data-sources/credential_username.md
@@ -5,7 +5,7 @@ Get the attributes of a username credential within Jenkins.
 ## Example Usage
 
 ```hcl
-data jenkins_credential_username example {
+data "jenkins_credential_username" "example" {
   name        = "job-name"
 }
 ```

--- a/docs/data-sources/credential_vault_approle.md
+++ b/docs/data-sources/credential_vault_approle.md
@@ -7,7 +7,7 @@ Get the attributes of a Vault AppRole credential within Jenkins.
 ## Example Usage
 
 ```hcl
-data jenkins_credential_vault_approle example {
+data "jenkins_credential_vault_approle" "example" {
   name        = "job-name"
 }
 ```

--- a/docs/data-sources/folder.md
+++ b/docs/data-sources/folder.md
@@ -7,7 +7,7 @@ Get the attributes of a folder within Jenkins.
 ## Example Usage
 
 ```hcl
-data jenkins_folder example {
+data "jenkins_folder" "example" {
   name        = "folder-name"
 }
 ```

--- a/docs/data-sources/job.md
+++ b/docs/data-sources/job.md
@@ -5,7 +5,7 @@ Get the attributes of a job within Jenkins.
 ## Example Usage
 
 ```hcl
-data jenkins_job example {
+data "jenkins_job" "example" {
   name        = "job-name"
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ provider "jenkins" {}
 Usage:
 
 ```sh
-$ export JENKINS_SERVER_URL="https://jenkins.url"
+$ export JENKINS_URL="https://jenkins.url"
 $ export JENKINS_USERNAME="username"
 $ export JENKINS_PASSWORD="password"
 $ terraform plan

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ The Jenkins provider is used to interact with the Jenkins API. The provider need
 
 ```hcl
 # Configure the Jenkins Provider
-provider jenkins {
+provider "jenkins" {
   server_url = "https://jenkins.url" # Or use JENKINS_URL env var
   username   = "username"            # Or use JENKINS_USERNAME env var
   password   = "password"            # Or use JENKINS_PASSWORD env var
@@ -14,7 +14,7 @@ provider jenkins {
 }
 
 # Create a Jenkins job
-resource jenkins_job example {
+resource "jenkins_job" "example" {
   # ...
 }
 ```
@@ -30,7 +30,7 @@ Static credentials can be provided by adding a `username` and `password` in-line
 Usage:
 
 ```hcl
-provider jenkins {
+provider "jenkins" {
   server_url = "https://jenkins.url"
   username   = "username"
   password   = "password"
@@ -42,7 +42,7 @@ provider jenkins {
 You can provide your credentials via the `JENKINS_USERNAME` and `JENKINS_PASSWORD`, environment variables. `JENKINS_URL` is also available which will assign the `server_url` property.
 
 ```hcl
-provider jenkins {}
+provider "jenkins" {}
 ```
 
 Usage:

--- a/docs/resources/credential_username.md
+++ b/docs/resources/credential_username.md
@@ -7,7 +7,7 @@ Manages a username credential within Jenkins. This username may then be referenc
 ## Example Usage
 
 ```hcl
-resource jenkins_credential_username example {
+resource "jenkins_credential_username" "example" {
   name     = "example-username"
   username = "example"
   password = "super-secret"

--- a/docs/resources/credential_vault_approle.md
+++ b/docs/resources/credential_vault_approle.md
@@ -9,7 +9,7 @@ Manages a Vault AppRole credential within Jenkins. This credential may then be r
 ## Example Usage
 
 ```hcl
-resource jenkins_credential_vault_approle example {
+resource "jenkins_credential_vault_approle" "example" {
   name     = "example-approle"
   role_id = "example"
   secret_id = "super-secret"

--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -7,12 +7,12 @@ Manages a folder within Jenkins.
 ## Example Usage
 
 ```hcl
-resource jenkins_folder example {
+resource "jenkins_folder" "example" {
   name        = "folder-name"
   description = "A top-level folder"
 }
 
-resource jenkins_folder example_child {
+resource "jenkins_folder" "example_child" {
   name        = "child-name"
   folder      = jenkins_folder.example.id
   description = "A nested subfolder"

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -5,11 +5,11 @@ Manages a job within Jenkins.
 ## Example Usage
 
 ```hcl
-resource jenkins_folder example {
+resource "jenkins_folder" "example" {
   name = "folder-name"
 }
 
-resource jenkins_job example {
+resource "jenkins_job" "example" {
   name     = "example"
   folder   = jenkins_folder.example.id
   template = file("${path.module}/job.xml")

--- a/example/providers.tf
+++ b/example/providers.tf
@@ -1,6 +1,6 @@
 # Connects to the instance launched through "docker-compose up -d"
 # Once done with testing, clean up the instance with "docker-compose down --volumes"
-provider jenkins {
+provider "jenkins" {
   server_url = "http://localhost:8080" # Or use JENKINS_URL env var
   username   = "admin"                 # Or use JENKINS_USERNAME env var
   password   = "admin"                 # Or use JENKINS_PASSWORD env var


### PR DESCRIPTION
# Dependencies

Holding on merge for the impending #36, which is adding new resource documentation.

# What Is Changing

Updating documentation to conform to TF 0.14+'s more strict `fmt` rules, which automatically add quotes around resource types and names.

Fixing a typo where the examples use `JENKINS_SERVER_URL` as the env var rather than `JENKINS_URL`.

Fixes #34 

# Test Steps

```sh
make testacc
```
