### PR TITLE
Added support for secret file credentials, bumped gojenkins to latest…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ terraform.tfstate*
 *.test
 vendor
 dist/
+coverage.txt

--- a/docs/resources/credential_secret_file.md
+++ b/docs/resources/credential_secret_file.md
@@ -1,0 +1,30 @@
+# jenkins_credential_secret_file Resource
+
+Manages a secret file credential within Jenkins. This secret file may then be referenced within jobs that are created.
+
+## Example Usage
+
+```hcl
+resource "jenkins_credential_secret_file" "example" {
+  name        = "example-secret-file"
+  filename    = "secret-file.txt"
+  secretbytes = base64encode("My secret file very secret content.")
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the credentials being created. This maps to the ID property within Jenkins, and cannot be changed once set.
+* `domain` - (Optional) The domain store to place the credentials into. If not set will default to the global credentials store.
+* `folder` - (Optional) The folder namespace to store the credentials in. If not set will default to global Jenkins credentials.
+* `scope` - (Optional) The visibility of the credentials to Jenkins agents. This must be set to either "GLOBAL" or "SYSTEM". If not set will default to "GLOBAL".
+* `description` - (Optional) A human readable description of the credentials being stored.
+* `filename` - (Required) The secret file filename on jenkins server side.
+* `secretbyes` - (Required) The secret file, base64 encoded content. I can be sourced directly from local file with filebase64(path) TF function or given directly.
+
+
+## Attribute Reference
+
+All arguments above are exported.

--- a/docs/resources/credential_secret_file.md
+++ b/docs/resources/credential_secret_file.md
@@ -22,7 +22,7 @@ The following arguments are supported:
 * `scope` - (Optional) The visibility of the credentials to Jenkins agents. This must be set to either "GLOBAL" or "SYSTEM". If not set will default to "GLOBAL".
 * `description` - (Optional) A human readable description of the credentials being stored.
 * `filename` - (Required) The secret file filename on jenkins server side.
-* `secretbyes` - (Required) The secret file, base64 encoded content. I can be sourced directly from local file with filebase64(path) TF function or given directly.
+* `secretbytes` - (Required) The secret file, base64 encoded content. It can be sourced directly from local file with filebase64(path) TF function or given directly.
 
 
 ## Attribute Reference

--- a/example/credentials_secret_file.tf
+++ b/example/credentials_secret_file.tf
@@ -1,0 +1,16 @@
+resource "jenkins_credential_secret_file" "global" {
+  name   = "global-secret-file"
+  filename = "secret-file.txt"
+  // This can also be read directy from file like this:
+  // filebase64("${path.module}/hello.txt")
+  secretbytes = base64encode("My secret file content.")
+}
+
+resource "jenkins_credential_secret_file" "folder" {
+  name   = "folder-secret-file"
+  folder = jenkins_folder.example.id
+  filename = "secret-file.txt"
+  // This can also be read directy from file like this:
+  // filebase64("${path.module}/hello.txt")
+  secretbytes = base64encode("My secret file content.")
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/aws/aws-sdk-go v1.30.12 // indirect
-	github.com/bndr/gojenkins v1.0.2-0.20200401074816-65ee8c9388b5
+	github.com/bndr/gojenkins v1.1.1-0.20210407143218-9e2483ff7ebd
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	golang.org/x/net v0.0.0-20201209123823-ac852fbbde11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bndr/gojenkins v1.0.2-0.20200401074816-65ee8c9388b5 h1:akFW14Is0lbOE/QXti6LZ4NNURCb+A9DBDqeX+R9MlI=
 github.com/bndr/gojenkins v1.0.2-0.20200401074816-65ee8c9388b5/go.mod h1:QeskxN9F/Csz0XV/01IC8y37CapKKWvOHa0UHLLX1fM=
+github.com/bndr/gojenkins v1.1.1-0.20210407143218-9e2483ff7ebd h1:vyQExnC9tUT3rISUqW75vtcA1AM4fmfdojSrU1OZTlk=
+github.com/bndr/gojenkins v1.1.1-0.20210407143218-9e2483ff7ebd/go.mod h1:QeskxN9F/Csz0XV/01IC8y37CapKKWvOHa0UHLLX1fM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/jenkins/config.go
+++ b/jenkins/config.go
@@ -1,6 +1,7 @@
 package jenkins
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"strings"
@@ -9,11 +10,11 @@ import (
 )
 
 type jenkinsClient interface {
-	CreateJobInFolder(config string, jobName string, parentIDs ...string) (*jenkins.Job, error)
+	CreateJobInFolder(ctx context.Context, config string, jobName string, parentIDs ...string) (*jenkins.Job, error)
 	Credentials() *jenkins.CredentialsManager
-	DeleteJobInFolder(name string, parentIDs ...string) (bool, error)
-	GetJob(id string, parentIDs ...string) (*jenkins.Job, error)
-	GetFolder(id string, parents ...string) (*jenkins.Folder, error)
+	DeleteJobInFolder(ctx context.Context, name string, parentIDs ...string) (bool, error)
+	GetJob(ctx context.Context, id string, parentIDs ...string) (*jenkins.Job, error)
+	GetFolder(ctx context.Context, id string, parents ...string) (*jenkins.Folder, error)
 }
 
 // jenkinsAdapter wraps the Jenkins client, enabling additional functionality
@@ -48,6 +49,6 @@ func (j *jenkinsAdapter) Credentials() *jenkins.CredentialsManager {
 
 // DeleteJobInFolder assists in running DeleteJob funcs, as DeleteJob is not folder aware
 // and cannot take a canonical job ID without mishandling it.
-func (j *jenkinsAdapter) DeleteJobInFolder(name string, parentIDs ...string) (bool, error) {
-	return j.DeleteJob(strings.Join(append(parentIDs, name), "/job/"))
+func (j *jenkinsAdapter) DeleteJobInFolder(ctx context.Context, name string, parentIDs ...string) (bool, error) {
+	return j.DeleteJob(ctx, strings.Join(append(parentIDs, name), "/job/"))
 }

--- a/jenkins/config_test.go
+++ b/jenkins/config_test.go
@@ -2,36 +2,37 @@ package jenkins
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	jenkins "github.com/bndr/gojenkins"
 )
 
 type mockJenkinsClient struct {
-	mockCreateJobInFolder func(config string, jobName string, parentIDs ...string) (*jenkins.Job, error)
-	mockDeleteJobInFolder func(name string, parentIDs ...string) (bool, error)
-	mockGetJob            func(id string, parentIDs ...string) (*jenkins.Job, error)
-	mockGetFolder         func(id string, parentIDs ...string) (*jenkins.Folder, error)
+	mockCreateJobInFolder func(ctx context.Context, config string, jobName string, parentIDs ...string) (*jenkins.Job, error)
+	mockDeleteJobInFolder func(ctx context.Context, name string, parentIDs ...string) (bool, error)
+	mockGetJob            func(ctx context.Context, id string, parentIDs ...string) (*jenkins.Job, error)
+	mockGetFolder         func(ctx context.Context, id string, parentIDs ...string) (*jenkins.Folder, error)
 }
 
-func (m *mockJenkinsClient) CreateJobInFolder(config string, jobName string, parentIDs ...string) (*jenkins.Job, error) {
-	return m.mockCreateJobInFolder(config, jobName, parentIDs...)
+func (m *mockJenkinsClient) CreateJobInFolder(ctx context.Context, config string, jobName string, parentIDs ...string) (*jenkins.Job, error) {
+	return m.mockCreateJobInFolder(ctx, config, jobName, parentIDs...)
 }
 
 func (m *mockJenkinsClient) Credentials() *jenkins.CredentialsManager {
 	return &jenkins.CredentialsManager{}
 }
 
-func (m *mockJenkinsClient) DeleteJobInFolder(name string, parentIDs ...string) (bool, error) {
-	return m.mockDeleteJobInFolder(name, parentIDs...)
+func (m *mockJenkinsClient) DeleteJobInFolder(ctx context.Context, name string, parentIDs ...string) (bool, error) {
+	return m.mockDeleteJobInFolder(ctx, name, parentIDs...)
 }
 
-func (m *mockJenkinsClient) GetJob(id string, parentIDs ...string) (*jenkins.Job, error) {
-	return m.mockGetJob(id, parentIDs...)
+func (m *mockJenkinsClient) GetJob(ctx context.Context, id string, parentIDs ...string) (*jenkins.Job, error) {
+	return m.mockGetJob(ctx, id, parentIDs...)
 }
 
-func (m *mockJenkinsClient) GetFolder(id string, parentIDs ...string) (*jenkins.Folder, error) {
-	return m.mockGetFolder(id, parentIDs...)
+func (m *mockJenkinsClient) GetFolder(ctx context.Context, id string, parentIDs ...string) (*jenkins.Folder, error) {
+	return m.mockGetFolder(ctx, id, parentIDs...)
 }
 
 func TestNewJenkinsClient(t *testing.T) {

--- a/jenkins/provider.go
+++ b/jenkins/provider.go
@@ -46,7 +46,7 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-                        "jenkins_credential_secret_file":   resourceJenkinsCredentialSecretFile(),
+			"jenkins_credential_secret_file":   resourceJenkinsCredentialSecretFile(),
 			"jenkins_credential_secret_text":   resourceJenkinsCredentialSecretText(),
 			"jenkins_credential_username":      resourceJenkinsCredentialUsername(),
 			"jenkins_credential_vault_approle": resourceJenkinsCredentialVaultAppRole(),

--- a/jenkins/provider.go
+++ b/jenkins/provider.go
@@ -46,6 +46,7 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+                        "jenkins_credential_secret_file":   resourceJenkinsCredentialSecretFile(),
 			"jenkins_credential_secret_text":   resourceJenkinsCredentialSecretText(),
 			"jenkins_credential_username":      resourceJenkinsCredentialUsername(),
 			"jenkins_credential_vault_approle": resourceJenkinsCredentialVaultAppRole(),
@@ -74,7 +75,7 @@ func configureProvider(ctx context.Context, d *schema.ResourceData) (interface{}
 	}
 
 	client := newJenkinsClient(&config)
-	if _, err = client.Init(); err != nil {
+	if _, err = client.Init(ctx); err != nil {
 		return nil, diag.FromErr(err)
 	}
 

--- a/jenkins/resource_jenkins_credential_secret_file.go
+++ b/jenkins/resource_jenkins_credential_secret_file.go
@@ -53,11 +53,11 @@ func resourceJenkinsCredentialSecretFile() *schema.Resource {
 				Optional:    true,
 				Default:     "Managed by Terraform",
 			},
-                        "filename": {
-                                Type:        schema.TypeString,
-                                Description: "Jenkins side filename.",
-                                Required:    true,
-                        },
+			"filename": {
+				Type:        schema.TypeString,
+				Description: "Jenkins side filename.",
+				Required:    true,
+			},
 			"secretbytes": {
 				Type:        schema.TypeString,
 				Description: "Base64 encoded secret file content.",
@@ -82,7 +82,7 @@ func resourceJenkinsCredentialSecretFileCreate(ctx context.Context, d *schema.Re
 		ID:          d.Get("name").(string),
 		Scope:       d.Get("scope").(string),
 		Description: d.Get("description").(string),
-                Filename:    d.Get("filename").(string),
+		Filename:    d.Get("filename").(string),
 		SecretBytes: d.Get("secretbytes").(string),
 	}
 
@@ -121,7 +121,7 @@ func resourceJenkinsCredentialSecretFileRead(ctx context.Context, d *schema.Reso
 	d.SetId(generateCredentialID(d.Get("folder").(string), cred.ID))
 	d.Set("scope", cred.Scope)
 	d.Set("description", cred.Description)
-        d.Set("filename", cred.Filename)
+	d.Set("filename", cred.Filename)
 	// NOTE: We are NOT setting the secret here, as the secret returned by GetSingle is garbage
 	// Secret only applies to Create/Update operations if the "password" property is non-empty
 
@@ -137,7 +137,7 @@ func resourceJenkinsCredentialSecretFileUpdate(ctx context.Context, d *schema.Re
 		ID:          d.Get("name").(string),
 		Scope:       d.Get("scope").(string),
 		Description: d.Get("description").(string),
-                Filename:    d.Get("filename").(string),
+		Filename:    d.Get("filename").(string),
 		SecretBytes: d.Get("secretbytes").(string),
 	}
 

--- a/jenkins/resource_jenkins_credential_secret_file.go
+++ b/jenkins/resource_jenkins_credential_secret_file.go
@@ -2,33 +2,22 @@ package jenkins
 
 import (
 	"context"
-	"encoding/xml"
 	"fmt"
 	"strings"
 
+	jenkins "github.com/bndr/gojenkins"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// VaultAppRoleCredentials struct representing credential for storing Vault AppRole role id and secret id
-type VaultAppRoleCredentials struct {
-	XMLName     xml.Name `xml:"com.datapipe.jenkins.vault.credentials.VaultAppRoleCredential"`
-	ID          string   `xml:"id"`
-	Scope       string   `xml:"scope"`
-	Description string   `xml:"description"`
-	Path        string   `xml:"path"`
-	RoleID      string   `xml:"roleId"`
-	SecretID    string   `xml:"secretId"`
-}
-
-func resourceJenkinsCredentialVaultAppRole() *schema.Resource {
+func resourceJenkinsCredentialSecretFile() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceJenkinsCredentialVaultAppRoleCreate,
-		ReadContext:   resourceJenkinsCredentialVaultAppRoleRead,
-		UpdateContext: resourceJenkinsCredentialVaultAppRoleUpdate,
-		DeleteContext: resourceJenkinsCredentialVaultAppRoleDelete,
+		CreateContext: resourceJenkinsCredentialSecretFileCreate,
+		ReadContext:   resourceJenkinsCredentialSecretFileRead,
+		UpdateContext: resourceJenkinsCredentialSecretFileUpdate,
+		DeleteContext: resourceJenkinsCredentialSecretFileDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceJenkinsCredentialVaultAppRoleImport,
+			StateContext: resourceJenkinsCredentialSecretFileImport,
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -64,61 +53,54 @@ func resourceJenkinsCredentialVaultAppRole() *schema.Resource {
 				Optional:    true,
 				Default:     "Managed by Terraform",
 			},
-			"path": {
+                        "filename": {
+                                Type:        schema.TypeString,
+                                Description: "Jenkins side filename.",
+                                Required:    true,
+                        },
+			"secretbytes": {
 				Type:        schema.TypeString,
-				Description: "Path of the roles approle backend.",
-				Optional:    true,
-				Default:     "approle",
-			},
-			"role_id": {
-				Type:        schema.TypeString,
-				Description: "The roles role_id.",
+				Description: "Base64 encoded secret file content.",
 				Required:    true,
-			},
-			"secret_id": {
-				Type:        schema.TypeString,
-				Description: "The roles secret_id. If left empty will be unmanaged.",
-				Optional:    true,
 				Sensitive:   true,
 			},
 		},
 	}
 }
 
-func resourceJenkinsCredentialVaultAppRoleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJenkinsCredentialSecretFileCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(jenkinsClient)
 	cm := client.Credentials()
 	cm.Folder = formatFolderName(d.Get("folder").(string))
-	// return diag.FromErr(fmt.Errorf("invalid folder name '%s', '%s'", cm.Folder, d.Get("folder").(string)))
+
 	// Validate that the folder exists
 	if err := folderExists(ctx, client, cm.Folder); err != nil {
 		return diag.FromErr(fmt.Errorf("invalid folder name '%s' specified: %w", cm.Folder, err))
 	}
 
-	cred := VaultAppRoleCredentials{
+	cred := jenkins.FileCredentials{
 		ID:          d.Get("name").(string),
 		Scope:       d.Get("scope").(string),
 		Description: d.Get("description").(string),
-		Path:        d.Get("path").(string),
-		RoleID:      d.Get("role_id").(string),
-		SecretID:    d.Get("secret_id").(string),
+                Filename:    d.Get("filename").(string),
+		SecretBytes: d.Get("secretbytes").(string),
 	}
 
 	domain := d.Get("domain").(string)
 	err := cm.Add(ctx, domain, cred)
 	if err != nil {
-		return diag.Errorf("Could not create vault approle credentials: %s", err)
+		return diag.Errorf("Could not create secret text credentials: %s", err)
 	}
 
 	d.SetId(generateCredentialID(d.Get("folder").(string), cred.ID))
-	return resourceJenkinsCredentialVaultAppRoleRead(ctx, d, meta)
+	return resourceJenkinsCredentialSecretFileRead(ctx, d, meta)
 }
 
-func resourceJenkinsCredentialVaultAppRoleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJenkinsCredentialSecretFileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cm := meta.(jenkinsClient).Credentials()
 	cm.Folder = formatFolderName(d.Get("folder").(string))
 
-	cred := VaultAppRoleCredentials{}
+	cred := jenkins.FileCredentials{}
 	err := cm.GetSingle(
 		ctx,
 		d.Get("domain").(string),
@@ -133,48 +115,42 @@ func resourceJenkinsCredentialVaultAppRoleRead(ctx context.Context, d *schema.Re
 			return nil
 		}
 
-		return diag.Errorf("Could not read vault approle credentials: %s", err)
+		return diag.Errorf("Could not read secret text credentials: %s", err)
 	}
 
 	d.SetId(generateCredentialID(d.Get("folder").(string), cred.ID))
 	d.Set("scope", cred.Scope)
 	d.Set("description", cred.Description)
-	d.Set("path", cred.Path)
-	d.Set("role_id", cred.RoleID)
-	// NOTE: We are NOT setting the password here, as the password returned by GetSingle is garbage
-	// Password only applies to Create/Update operations if the "password" property is non-empty
+        d.Set("filename", cred.Filename)
+	// NOTE: We are NOT setting the secret here, as the secret returned by GetSingle is garbage
+	// Secret only applies to Create/Update operations if the "password" property is non-empty
 
 	return nil
 }
 
-func resourceJenkinsCredentialVaultAppRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJenkinsCredentialSecretFileUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cm := meta.(jenkinsClient).Credentials()
 	cm.Folder = formatFolderName(d.Get("folder").(string))
 
 	domain := d.Get("domain").(string)
-	cred := VaultAppRoleCredentials{
+	cred := jenkins.FileCredentials{
 		ID:          d.Get("name").(string),
 		Scope:       d.Get("scope").(string),
 		Description: d.Get("description").(string),
-		Path:        d.Get("path").(string),
-		RoleID:      d.Get("role_id").(string),
-	}
-
-	// Only enforce the password if it is non-empty
-	if d.Get("secret_id").(string) != "" {
-		cred.SecretID = d.Get("secret_id").(string)
+                Filename:    d.Get("filename").(string),
+		SecretBytes: d.Get("secretbytes").(string),
 	}
 
 	err := cm.Update(ctx, domain, d.Get("name").(string), &cred)
 	if err != nil {
-		return diag.Errorf("Could not update vault approle credentials: %s", err)
+		return diag.Errorf("Could not update secret text: %s", err)
 	}
 
 	d.SetId(generateCredentialID(d.Get("folder").(string), cred.ID))
-	return resourceJenkinsCredentialVaultAppRoleRead(ctx, d, meta)
+	return resourceJenkinsCredentialSecretFileRead(ctx, d, meta)
 }
 
-func resourceJenkinsCredentialVaultAppRoleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJenkinsCredentialSecretFileDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cm := meta.(jenkinsClient).Credentials()
 	cm.Folder = formatFolderName(d.Get("folder").(string))
 
@@ -190,7 +166,7 @@ func resourceJenkinsCredentialVaultAppRoleDelete(ctx context.Context, d *schema.
 	return nil
 }
 
-func resourceJenkinsCredentialVaultAppRoleImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceJenkinsCredentialSecretFileImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 	ret := []*schema.ResourceData{d}
 
 	splitID := strings.Split(d.Id(), "/")

--- a/jenkins/resource_jenkins_credential_secret_file_test.go
+++ b/jenkins/resource_jenkins_credential_secret_file_test.go
@@ -24,7 +24,7 @@ func TestAccJenkinsCredentialSecretFile_basic(t *testing.T) {
 				resource jenkins_credential_secret_file foo {
 				  name = "test-secret-file"
 				  filename = "secret.txt"             
-				  secretbytes = "VGhpcyBpcyBhIHRlc3Qu"
+				  secretbytes = base64encode("This is a test.")
 				}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("jenkins_credential_secret_file.foo", "id", "/test-secret-file"),
@@ -32,17 +32,17 @@ func TestAccJenkinsCredentialSecretFile_basic(t *testing.T) {
 				),
 			},
 			{
-				// Update by adding description
+				// Update by changing secretbytes
 				Config: `
 				resource jenkins_credential_secret_file foo {
 				  name = "test-secret-file"
-				  description = "new-description"
-                                  filename = "secret.txt"             
-                                  secretbytes = "VGhpcyBpcyBhIHRlc3Qu"
+				  filename = "secret.txt"             
+				  secretbytes = base64encode("This is a new secret content.")
 				}`,
+				// In comparison below I use already base64 encoded value of: VGhpcyBpcyBhIG5ldyBzZWNyZXQgY29udGVudC4=
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJenkinsCredentialSecretFileExists("jenkins_credential_secret_file.foo", &cred),
-					resource.TestCheckResourceAttr("jenkins_credential_secret_file.foo", "description", "new-description"),
+					resource.TestCheckResourceAttr("jenkins_credential_secret_file.foo", "secretbytes", "VGhpcyBpcyBhIG5ldyBzZWNyZXQgY29udGVudC4="),
 				),
 			},
 		},

--- a/jenkins/resource_jenkins_credential_secret_text.go
+++ b/jenkins/resource_jenkins_credential_secret_text.go
@@ -69,7 +69,7 @@ func resourceJenkinsCredentialSecretTextCreate(ctx context.Context, d *schema.Re
 	cm.Folder = formatFolderName(d.Get("folder").(string))
 
 	// Validate that the folder exists
-	if err := folderExists(client, cm.Folder); err != nil {
+	if err := folderExists(ctx, client, cm.Folder); err != nil {
 		return diag.FromErr(fmt.Errorf("invalid folder name '%s' specified: %w", cm.Folder, err))
 	}
 
@@ -81,7 +81,7 @@ func resourceJenkinsCredentialSecretTextCreate(ctx context.Context, d *schema.Re
 	}
 
 	domain := d.Get("domain").(string)
-	err := cm.Add(domain, cred)
+	err := cm.Add(ctx, domain, cred)
 	if err != nil {
 		return diag.Errorf("Could not create secret text credentials: %s", err)
 	}
@@ -96,6 +96,7 @@ func resourceJenkinsCredentialSecretTextRead(ctx context.Context, d *schema.Reso
 
 	cred := jenkins.StringCredentials{}
 	err := cm.GetSingle(
+		ctx,
 		d.Get("domain").(string),
 		d.Get("name").(string),
 		&cred,
@@ -132,7 +133,7 @@ func resourceJenkinsCredentialSecretTextUpdate(ctx context.Context, d *schema.Re
 		Secret:      d.Get("secret").(string),
 	}
 
-	err := cm.Update(domain, d.Get("name").(string), &cred)
+	err := cm.Update(ctx, domain, d.Get("name").(string), &cred)
 	if err != nil {
 		return diag.Errorf("Could not update secret text: %s", err)
 	}
@@ -146,6 +147,7 @@ func resourceJenkinsCredentialSecretTextDelete(ctx context.Context, d *schema.Re
 	cm.Folder = formatFolderName(d.Get("folder").(string))
 
 	err := cm.Delete(
+		ctx,
 		d.Get("domain").(string),
 		d.Get("name").(string),
 	)

--- a/jenkins/resource_jenkins_credential_username.go
+++ b/jenkins/resource_jenkins_credential_username.go
@@ -74,7 +74,7 @@ func resourceJenkinsCredentialUsernameCreate(ctx context.Context, d *schema.Reso
 	cm.Folder = formatFolderName(d.Get("folder").(string))
 
 	// Validate that the folder exists
-	if err := folderExists(client, cm.Folder); err != nil {
+	if err := folderExists(ctx, client, cm.Folder); err != nil {
 		return diag.FromErr(fmt.Errorf("invalid folder name '%s' specified: %w", cm.Folder, err))
 	}
 
@@ -87,7 +87,7 @@ func resourceJenkinsCredentialUsernameCreate(ctx context.Context, d *schema.Reso
 	}
 
 	domain := d.Get("domain").(string)
-	err := cm.Add(domain, cred)
+	err := cm.Add(ctx, domain, cred)
 	if err != nil {
 		return diag.Errorf("Could not create username credentials: %s", err)
 	}
@@ -102,6 +102,7 @@ func resourceJenkinsCredentialUsernameRead(ctx context.Context, d *schema.Resour
 
 	cred := jenkins.UsernameCredentials{}
 	err := cm.GetSingle(
+		ctx,
 		d.Get("domain").(string),
 		d.Get("name").(string),
 		&cred,
@@ -144,7 +145,7 @@ func resourceJenkinsCredentialUsernameUpdate(ctx context.Context, d *schema.Reso
 		cred.Password = d.Get("password").(string)
 	}
 
-	err := cm.Update(domain, d.Get("name").(string), &cred)
+	err := cm.Update(ctx, domain, d.Get("name").(string), &cred)
 	if err != nil {
 		return diag.Errorf("Could not update username credentials: %s", err)
 	}
@@ -158,6 +159,7 @@ func resourceJenkinsCredentialUsernameDelete(ctx context.Context, d *schema.Reso
 	cm.Folder = formatFolderName(d.Get("folder").(string))
 
 	err := cm.Delete(
+		ctx,
 		d.Get("domain").(string),
 		d.Get("name").(string),
 	)

--- a/jenkins/resource_jenkins_credential_username_test.go
+++ b/jenkins/resource_jenkins_credential_username_test.go
@@ -1,6 +1,7 @@
 package jenkins
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -125,6 +126,7 @@ func TestAccJenkinsCredentialUsername_folder(t *testing.T) {
 func testAccCheckJenkinsCredentialUsernameExists(resourceName string, cred *jenkins.UsernameCredentials) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(jenkinsClient)
+		ctx := context.Background()
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -137,7 +139,7 @@ func testAccCheckJenkinsCredentialUsernameExists(resourceName string, cred *jenk
 
 		manager := client.Credentials()
 		manager.Folder = formatFolderName(rs.Primary.Attributes["folder"])
-		err := manager.GetSingle(rs.Primary.Attributes["domain"], rs.Primary.Attributes["name"], cred)
+		err := manager.GetSingle(ctx, rs.Primary.Attributes["domain"], rs.Primary.Attributes["name"], cred)
 		if err != nil {
 			return fmt.Errorf("Unable to retrieve credentials for %s - %s: %w", rs.Primary.Attributes["folder"], rs.Primary.Attributes["name"], err)
 		}
@@ -148,6 +150,7 @@ func testAccCheckJenkinsCredentialUsernameExists(resourceName string, cred *jenk
 
 func testAccCheckJenkinsCredentialUsernameDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(jenkinsClient)
+	ctx := context.Background()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "jenkins_credential_username" {
@@ -159,7 +162,7 @@ func testAccCheckJenkinsCredentialUsernameDestroy(s *terraform.State) error {
 		cred := jenkins.UsernameCredentials{}
 		manager := client.Credentials()
 		manager.Folder = formatFolderName(rs.Primary.Meta["folder"].(string))
-		err := manager.GetSingle(rs.Primary.Meta["domain"].(string), rs.Primary.Meta["name"].(string), &cred)
+		err := manager.GetSingle(ctx, rs.Primary.Meta["domain"].(string), rs.Primary.Meta["name"].(string), &cred)
 		if err == nil {
 			return fmt.Errorf("Credentials still exists: %s - %s", rs.Primary.Attributes["folder"], rs.Primary.Attributes["name"])
 		}

--- a/jenkins/resource_jenkins_credential_vault_approle_test.go
+++ b/jenkins/resource_jenkins_credential_vault_approle_test.go
@@ -1,6 +1,7 @@
 package jenkins
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -132,6 +133,7 @@ func TestAccJenkinsCredentialVaultAppRole_folder(t *testing.T) {
 func testAccCheckJenkinsCredentialVaultAppRoleExists(resourceName string, cred *VaultAppRoleCredentials) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(jenkinsClient)
+		ctx := context.Background()
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -144,7 +146,7 @@ func testAccCheckJenkinsCredentialVaultAppRoleExists(resourceName string, cred *
 
 		manager := client.Credentials()
 		manager.Folder = formatFolderName(rs.Primary.Attributes["folder"])
-		err := manager.GetSingle(rs.Primary.Attributes["domain"], rs.Primary.Attributes["name"], cred)
+		err := manager.GetSingle(ctx, rs.Primary.Attributes["domain"], rs.Primary.Attributes["name"], cred)
 		if err != nil {
 			return fmt.Errorf("Unable to retrieve credentials for %s - %s: %w", rs.Primary.Attributes["folder"], rs.Primary.Attributes["name"], err)
 		}
@@ -155,6 +157,7 @@ func testAccCheckJenkinsCredentialVaultAppRoleExists(resourceName string, cred *
 
 func testAccCheckJenkinsCredentialVaultAppRoleDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(jenkinsClient)
+	ctx := context.Background()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "jenkins_credential_vault_approle" {
@@ -166,7 +169,7 @@ func testAccCheckJenkinsCredentialVaultAppRoleDestroy(s *terraform.State) error 
 		cred := VaultAppRoleCredentials{}
 		manager := client.Credentials()
 		manager.Folder = formatFolderName(rs.Primary.Meta["folder"].(string))
-		err := manager.GetSingle(rs.Primary.Meta["domain"].(string), rs.Primary.Meta["name"].(string), &cred)
+		err := manager.GetSingle(ctx, rs.Primary.Meta["domain"].(string), rs.Primary.Meta["name"].(string), &cred)
 		if err == nil {
 			return fmt.Errorf("Credentials still exists: %s - %s", rs.Primary.Attributes["folder"], rs.Primary.Attributes["name"])
 		}

--- a/jenkins/resource_jenkins_folder_test.go
+++ b/jenkins/resource_jenkins_folder_test.go
@@ -1,6 +1,7 @@
 package jenkins
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -66,13 +67,14 @@ func TestAccJenkinsFolder_nested(t *testing.T) {
 
 func testAccCheckJenkinsFolderDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(jenkinsClient)
+	ctx := context.Background()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "jenkins_folder" {
 			continue
 		}
 
-		_, err := client.GetJob(rs.Primary.ID)
+		_, err := client.GetJob(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Folder %s still exists", rs.Primary.ID)
 		}

--- a/jenkins/resource_jenkins_job_test.go
+++ b/jenkins/resource_jenkins_job_test.go
@@ -86,13 +86,14 @@ func TestAccJenkinsJob_nested(t *testing.T) {
 
 func testAccCheckJenkinsJobDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(jenkinsClient)
+	ctx := context.Background()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "jenkins_job" {
 			continue
 		}
 
-		_, err := client.GetJob(rs.Primary.ID)
+		_, err := client.GetJob(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Job %s still exists", rs.Primary.ID)
 		}
@@ -116,7 +117,7 @@ func Test_resourceJenkinsJobDelete(t *testing.T) {
 			name: "success",
 			args: args{
 				meta: &mockJenkinsClient{
-					mockDeleteJobInFolder: func(name string, parentIDs ...string) (bool, error) {
+					mockDeleteJobInFolder: func(ctx context.Context, name string, parentIDs ...string) (bool, error) {
 						return true, nil
 					},
 				},
@@ -127,7 +128,7 @@ func Test_resourceJenkinsJobDelete(t *testing.T) {
 			name: "error",
 			args: args{
 				meta: &mockJenkinsClient{
-					mockDeleteJobInFolder: func(name string, parentIDs ...string) (bool, error) {
+					mockDeleteJobInFolder: func(ctx context.Context, name string, parentIDs ...string) (bool, error) {
 						return false, fmt.Errorf("omg")
 					},
 				},
@@ -162,7 +163,7 @@ func Test_resourceJenkinsJobRead(t *testing.T) {
 			name: "missing-job",
 			args: args{
 				meta: &mockJenkinsClient{
-					mockGetJob: func(id string, parentIDs ...string) (*jenkins.Job, error) {
+					mockGetJob: func(ctx context.Context, id string, parentIDs ...string) (*jenkins.Job, error) {
 						return nil, fmt.Errorf("404")
 					},
 				},
@@ -173,7 +174,7 @@ func Test_resourceJenkinsJobRead(t *testing.T) {
 			name: "error-job",
 			args: args{
 				meta: &mockJenkinsClient{
-					mockGetJob: func(id string, parentIDs ...string) (*jenkins.Job, error) {
+					mockGetJob: func(ctx context.Context, id string, parentIDs ...string) (*jenkins.Job, error) {
 						return nil, fmt.Errorf("500")
 					},
 				},

--- a/jenkins/util.go
+++ b/jenkins/util.go
@@ -1,6 +1,7 @@
 package jenkins
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -60,11 +61,11 @@ func parseCanonicalJobID(id string) (name string, folders []string) {
 }
 
 // folderExists will validate that a given folder name exists
-func folderExists(client jenkinsClient, name string) error {
+func folderExists(ctx context.Context, client jenkinsClient, name string) error {
 	folders := extractFolders(name)
 	if len(folders) > 0 {
 		folderName, parentFolders := parseCanonicalJobID(name)
-		_, err := client.GetFolder(folderName, parentFolders...)
+		_, err := client.GetFolder(ctx, folderName, parentFolders...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
… and made needed adjustments.

Signed-off-by: Jacek Kikiewicz <public@kikiewicz.com>

# Dependencies

gojenkins updated to latest (already done as part of this commit)

# What Is Changing

I added support for secret file credential type, as part of this I had to update gojenkins dep to latest version because FileCredential wasn't supported by it before ( https://github.com/bndr/gojenkins/pull/233 ). Given there were some other changes in gojenkins in between I had to make adjustments all over the place to make it work with latest gojenkins.
Example and doc is added.
Test is added.
ACC tests are green locally.

# Test Steps

```sh
make testacc
```

<!-- Additional test steps beyond the acceptance tests go here. -->
