### PR TITLE
Add support for importing `jenkins_job` resource

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -66,3 +66,11 @@ The following arguments are supported:
 ## Attribute Reference
 
 All arguments above are exported.
+
+## Import
+
+Jobs may be imported by their canonical name, e.g.
+
+```sh
+$ terraform import jenkins_job.example /job/job-name
+```

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -74,3 +74,5 @@ Jobs may be imported by their canonical name, e.g.
 ```sh
 $ terraform import jenkins_job.example /job/job-name
 ```
+
+Please note that in some cases, the imported XML may not fully match the template you are specifying in your resource, therefore please run a `terraform plan`, and if there are any template XML changes, run `terraform apply` to ensure your Terraform state file is fully in sync.

--- a/jenkins/resource_jenkins_job.go
+++ b/jenkins/resource_jenkins_job.go
@@ -16,6 +16,9 @@ func resourceJenkinsJob() *schema.Resource {
 		ReadContext:   resourceJenkinsJobRead,
 		UpdateContext: resourceJenkinsJobUpdate,
 		DeleteContext: resourceJenkinsJobDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:             schema.TypeString,


### PR DESCRIPTION
# Dependencies

No

# What Is Changing

Added ability to import `jenkins_job` resources so you can backport existing Jenkin's pipelines into Terraform.

# Test Steps

- [X] Have you updated the `docs/` folder to match your change?
- [X] Have you exercised your change using the `examples/` docker compose setup?

```sh
$ make test
go test -cover ./...
?       github.com/taiidani/terraform-provider-jenkins  [no test files]
ok      github.com/taiidani/terraform-provider-jenkins/jenkins  0.413s  coverage: 18.6% of statements
```

```sh
$ make testacc
TF_ACC=1 JENKINS_URL="http://localhost:8080" JENKINS_USERNAME="admin" JENKINS_PASSWORD="admin" go test -v -cover ./...
?       github.com/taiidani/terraform-provider-jenkins  [no test files]
=== RUN   TestNewJenkinsClient
--- PASS: TestNewJenkinsClient (0.00s)
=== RUN   TestJenkinsAdapter_Credentials
--- PASS: TestJenkinsAdapter_Credentials (0.00s)
=== RUN   TestAccJenkinsCredentialUsernameDataSource_basic
--- PASS: TestAccJenkinsCredentialUsernameDataSource_basic (2.09s)
=== RUN   TestAccJenkinsCredentialUsernameDataSource_nested
--- PASS: TestAccJenkinsCredentialUsernameDataSource_nested (1.93s)
=== RUN   TestAccJenkinsCredentialVaultAppRoleDataSource_basic
--- PASS: TestAccJenkinsCredentialVaultAppRoleDataSource_basic (1.52s)
=== RUN   TestAccJenkinsCredentialVaultAppRoleDataSource_nested
--- PASS: TestAccJenkinsCredentialVaultAppRoleDataSource_nested (1.65s)
=== RUN   TestAccJenkinsFolderDataSource_basic
--- PASS: TestAccJenkinsFolderDataSource_basic (1.51s)
=== RUN   TestAccJenkinsFolderDataSource_nested
--- PASS: TestAccJenkinsFolderDataSource_nested (1.72s)
=== RUN   TestAccJenkinsJobDataSource_basic
--- PASS: TestAccJenkinsJobDataSource_basic (1.64s)
=== RUN   TestAccJenkinsJobDataSource_nested
--- PASS: TestAccJenkinsJobDataSource_nested (1.65s)
=== RUN   Test_parseFolder
=== RUN   Test_parseFolder/success
=== RUN   Test_parseFolder/error-invalid-xml
--- PASS: Test_parseFolder (0.00s)
    --- PASS: Test_parseFolder/success (0.00s)
    --- PASS: Test_parseFolder/error-invalid-xml (0.00s)
=== RUN   Test_folder_Render
=== RUN   Test_folder_Render/success
--- PASS: Test_folder_Render (0.00s)
    --- PASS: Test_folder_Render/success (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestAccJenkinsCredentialSecretFile_basic
--- PASS: TestAccJenkinsCredentialSecretFile_basic (2.45s)
=== RUN   TestAccJenkinsCredentialSecretFile_folder
--- PASS: TestAccJenkinsCredentialSecretFile_folder (2.80s)
=== RUN   TestAccJenkinsCredentialSecretText_basic
--- PASS: TestAccJenkinsCredentialSecretText_basic (2.50s)
=== RUN   TestAccJenkinsCredentialSecretText_folder
--- PASS: TestAccJenkinsCredentialSecretText_folder (2.78s)
=== RUN   TestAccJenkinsCredentialSSH_basic
--- PASS: TestAccJenkinsCredentialSSH_basic (3.59s)
=== RUN   TestAccJenkinsCredentialSSH_folder
--- PASS: TestAccJenkinsCredentialSSH_folder (3.93s)
=== RUN   TestAccJenkinsCredentialUsername_basic
--- PASS: TestAccJenkinsCredentialUsername_basic (2.50s)
=== RUN   TestAccJenkinsCredentialUsername_folder
--- PASS: TestAccJenkinsCredentialUsername_folder (2.81s)
=== RUN   TestAccJenkinsCredentialVaultAppRole_basic
--- PASS: TestAccJenkinsCredentialVaultAppRole_basic (2.52s)
=== RUN   TestAccJenkinsCredentialVaultAppRole_folder
--- PASS: TestAccJenkinsCredentialVaultAppRole_folder (2.94s)
=== RUN   TestAccJenkinsFolder_basic
--- PASS: TestAccJenkinsFolder_basic (1.49s)
=== RUN   TestAccJenkinsFolder_withDisplayName
--- PASS: TestAccJenkinsFolder_withDisplayName (1.50s)
=== RUN   TestAccJenkinsFolder_nested
--- PASS: TestAccJenkinsFolder_nested (1.62s)
=== RUN   TestAccJenkinsJob_basic
--- PASS: TestAccJenkinsJob_basic (1.50s)
=== RUN   TestAccJenkinsJob_nested
--- PASS: TestAccJenkinsJob_nested (1.65s)
=== RUN   Test_resourceJenkinsJobDelete
=== RUN   Test_resourceJenkinsJobDelete/success
=== RUN   Test_resourceJenkinsJobDelete/error
--- PASS: Test_resourceJenkinsJobDelete (0.00s)
    --- PASS: Test_resourceJenkinsJobDelete/success (0.00s)
    --- PASS: Test_resourceJenkinsJobDelete/error (0.00s)
=== RUN   Test_resourceJenkinsJobRead
=== RUN   Test_resourceJenkinsJobRead/missing-job
=== RUN   Test_resourceJenkinsJobRead/error-job
--- PASS: Test_resourceJenkinsJobRead (0.00s)
    --- PASS: Test_resourceJenkinsJobRead/missing-job (0.00s)
    --- PASS: Test_resourceJenkinsJobRead/error-job (0.00s)
=== RUN   TestRenderTemplate
--- PASS: TestRenderTemplate (0.00s)
=== RUN   TestRenderTemplateInvalid
--- PASS: TestRenderTemplateInvalid (0.00s)
=== RUN   TestFormatFolderName
--- PASS: TestFormatFolderName (0.00s)
=== RUN   TestFormatFolderID
--- PASS: TestFormatFolderID (0.00s)
=== RUN   TestParseCanonicalJobID
--- PASS: TestParseCanonicalJobID (0.00s)
=== RUN   TestTemplateDiff
--- PASS: TestTemplateDiff (0.00s)
=== RUN   TestGenerateCredentialID
--- PASS: TestGenerateCredentialID (0.00s)
=== RUN   TestValidateJobName
--- PASS: TestValidateJobName (0.00s)
=== RUN   TestValidateFolderName
--- PASS: TestValidateFolderName (0.00s)
=== RUN   TestValidateCredentialScope
--- PASS: TestValidateCredentialScope (0.00s)
PASS
coverage: 67.2% of statements
ok      github.com/taiidani/terraform-provider-jenkins/jenkins  (cached)        coverage: 67.2% of statements
```

I created a job first via Terraform, deleted the state file, ran a plan to show Terraform wants to create it again, backported it using `terraform import` and ran a follow up plan.
```sh
$ terraform apply
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:


  # jenkins_job.test will be created
  + resource "jenkins_job" "test" {
      + id       = (known after apply)
      + name     = "Z Test Job"
      + template = <<-EOT
...
EOT
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

jenkins_job.test: Creating...
jenkins_job.test: Creation complete after 1s [id=/job/Z Test Job]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Job created, `terraform.tfstate` file deleted & re-ran `terraform plan` to ensure Terraform wanted to recreate this.
```sh
$ terraform plan
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:


  # jenkins_job.test will be created
  + resource "jenkins_job" "test" {
      + id       = (known after apply)
      + name     = "Z Test Job"
      + template = <<-EOT
...
EOT
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

Backported resource into Terraform
```sh
$ terraform import jenkins_job.test "/job/Z Test Job"
jenkins_job.test: Importing from ID "/job/Z Test Job"...
jenkins_job.test: Import prepared!
  Prepared jenkins_job for import
jenkins_job.test: Refreshing state... [id=/job/Z Test Job]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```

Re-ran plan to prove it was backported successfully 😃 
```sh
$ terraform plan
jenkins_job.test: Refreshing state... [id=/job/Z Test Job]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```