### PR TITLE
Fix typo in `validations_test.go`

### DIFF
--- a/jenkins/validations_test.go
+++ b/jenkins/validations_test.go
@@ -17,7 +17,7 @@ func TestValidateJobName(t *testing.T) {
 
 	// Test if we fail when we should
 	input = "job_name/second_level"
-	actual = validateCredentialScope(input, ctyPath)
+	actual = validateJobName(input, ctyPath)
 	if !actual.HasError() {
 		t.Errorf("Error, validation failed for input: %s", input)
 	}


### PR DESCRIPTION
# Dependencies

No

# What Is Changing

Fix typo in `validations_test.go`
Incorrect method was being called, i.e. not the one we are testing.

# Test Steps

```sh
$ make test
go test -cover ./...
?       github.com/taiidani/terraform-provider-jenkins  [no test files]
ok      github.com/taiidani/terraform-provider-jenkins/jenkins  (cached)        coverage: 18.8% of statements
```