### PR TITLE
Remove duplicate push target from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   lint:


### PR DESCRIPTION
# What Is Changing

Removing the "push" target from CI in favor of the "pull_request" target. This means that developers won't get as immediate feedback on their PRs due to the need to spin up a PR, but will halve the number of checks run per PR. Recommend developers use Draft PRs if they want to run their checks in CI.
