### PR TITLE
Bump Go to 1.19, Address deprecations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,18 +20,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Unshallow
         run: git fetch --prune --unshallow
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version-file: go.mod
+          cache: true
+
       - name: Import GPG key
         id: import_gpg
         uses: paultyng/ghaction-import-gpg@v2.1.0
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,25 +7,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version-file: go.mod
+          cache: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
+        with:
+          skip-pkg-cache: true
+          skip-build-cache: true
 
   unit:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+          go-version-file: go.mod
+          cache: true
 
       - run: go mod download
 
@@ -40,14 +44,13 @@ jobs:
   acceptance:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+          go-version-file: go.mod
+          cache: true
 
       - run: go mod download
 

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,5 +1,6 @@
 FROM jenkins/jenkins:lts
 
-RUN /usr/local/bin/install-plugins.sh hashicorp-vault-plugin cloudbees-folder pipeline-model-definition git matrix-auth
+RUN jenkins-plugin-cli --plugins \
+    hashicorp-vault-plugin cloudbees-folder pipeline-model-definition git matrix-auth
 
 HEALTHCHECK --interval=4s --start-period=5s --retries=30 CMD [ "curl", "-f", "http://localhost:8080" ]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/taiidani/terraform-provider-jenkins
 
-go 1.18
+go 1.19
 
 require (
 	github.com/bndr/gojenkins v1.1.1-0.20210407143218-9e2483ff7ebd

--- a/jenkins/config.go
+++ b/jenkins/config.go
@@ -3,7 +3,6 @@ package jenkins
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	jenkins "github.com/bndr/gojenkins"
@@ -34,7 +33,7 @@ func newJenkinsClient(c *Config) *jenkinsAdapter {
 	client := jenkins.CreateJenkins(nil, c.ServerURL, c.Username, c.Password)
 	if c.CACert != nil {
 		// provide CA certificate if server is using self-signed certificate
-		client.Requester.CACert, _ = ioutil.ReadAll(c.CACert)
+		client.Requester.CACert, _ = io.ReadAll(c.CACert)
 	}
 
 	// return the Jenkins API client


### PR DESCRIPTION
# Dependencies

Go 1.19

# What Is Changing

Bumping Go to 1.19. Refactoring some of the GitHub Actions workflows to better leverage caching and automatic version detection.

Addressing a deprecation of the `io/ioutil` Go standard library.

Addressing the removal of the Jenkins `install-plugins.sh` file in favor of the [jenkins-plugin-cli command](https://github.com/jenkinsci/docker/blob/master/README.md).

# Test Steps

- [x] Have you updated the `docs/` folder to match your change?
- [x] Have you exercised your change using the `examples/` docker compose setup?

```sh
make testacc
```

<!-- Additional test steps beyond the acceptance tests go here. -->
