### PR TITLE
Exempt enhancement label from stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,3 +21,4 @@ jobs:
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
         days-before-stale: 180
+        exempt-issue-labels: "enhancement"


### PR DESCRIPTION
# What Is Changing

Exempting "enahncement" issues from the stale close functionality, as they are feature requests not needing reproduction or otherwise N/A in terms of time limits.