### PR TITLE
Add CI for running example TF

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,3 +108,19 @@ jobs:
         run: |
           terraform init
           terraform apply -no-color -auto-approve
+
+      - name: Apply again
+        working-directory: example/
+        env:
+          JENKINS_URL: "http://localhost:8080"
+          JENKINS_USERNAME: "admin"
+          JENKINS_PASSWORD: "admin"
+        run: terraform apply -no-color -auto-approve
+
+      - name: Destroy example
+        working-directory: example/
+        env:
+          JENKINS_URL: "http://localhost:8080"
+          JENKINS_USERNAME: "admin"
+          JENKINS_PASSWORD: "admin"
+        run: terraform destroy -no-color -auto-approve

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,3 +74,37 @@ jobs:
         with:
           name: acceptance-coverage
           path: coverage.txt
+
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - run: go mod download
+
+      - name: Set up services
+        env:
+          COMPOSE_FILE: ./example/docker-compose.yml
+        run: |
+          docker-compose build
+          docker-compose up -d --force-recreate jenkins
+          while [ "$(docker inspect jenkins-provider-acc --format '{{ .State.Health.Status }}')" != "healthy" ]; do echo "Waiting for Jenkins to start..."; sleep 3; done
+
+      - name: Set up terraform
+        uses: hashicorp/setup-terraform@v2
+
+      - name: Run example
+        working-dir: example/
+        env:
+          JENKINS_URL: "http://localhost:8080"
+          JENKINS_USERNAME: "admin"
+          JENKINS_PASSWORD: "admin"
+        run: |
+          terraform init
+          terraform apply -no-color -auto-approve

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2
 
       - name: Run example
-        working-dir: example/
+        working-directory: example/
         env:
           JENKINS_URL: "http://localhost:8080"
           JENKINS_USERNAME: "admin"


### PR DESCRIPTION
# What Is Changing

Ensuring that the `example/` directory works for all developers by adding a CI job to run its Terraform.

# Test Steps

- [x] Have you updated the `docs/` folder to match your change?
- [x] Have you exercised your change using the `examples/` docker compose setup?

```sh
make testacc
```

<!-- Additional test steps beyond the acceptance tests go here. -->
