### PR TITLE
handleXml now uses regex to replace the XML version

### DIFF
--- a/jenkins/folder.go
+++ b/jenkins/folder.go
@@ -3,7 +3,7 @@ package jenkins
 import (
 	"encoding/xml"
 	"fmt"
-	"strings"
+	"regexp"
 )
 
 type folder struct {
@@ -54,6 +54,8 @@ func handleXml(def string) []byte {
 	// This is a horrible practice...but Go doesn't seem to have any mature
 	// support for the XML 1.1 specification. As long as Jenkins doesn't make
 	// use of any 1.1 additions then this should still parse.
-	def = strings.ReplaceAll(def, `<?xml version='1.1' encoding='UTF-8'?>`, `<?xml version='1.0' encoding='UTF-8'?>`)
+	re := regexp.MustCompile(`<\?xml version=(['"])([0-9]+\.[0-9]+)(['"])`)
+	def = re.ReplaceAllString(def, "<?xml version=${1}1.0${3}")
+
 	return []byte(def)
 }


### PR DESCRIPTION
# Dependencies

<!-- Does anything need to be performed as part of this change? -->

# What Is Changing

`handleXml` now uses a regex replace pattern to cover Jenkins deployments which do not respond with the hardcoded `<?xml version='1.1' encoding='UTF-8'?>`. In our use-case, the Jenkins Server response with `<?xml version="1.1" encoding="UTF-8" standalone="no"?>` which made the string no longer match.

# Test Steps

- [ ] Have you updated the `docs/` folder to match your change?
- [x] Have you exercised your change using the `examples/` docker compose setup?

```sh
make testacc
```

<!-- Additional test steps beyond the acceptance tests go here. -->
