### PR TITLE
Set username and password to optional

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,8 +60,8 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 
 * `server_url` - (Required) This is the Jenkins server URL. It should be fully qualified (e.g. `https://...`) and point to the root of the Jenkins server location.
 
-* `username` - (Required) This is Jenkins username for authentication.
+* `username` - (Optional) This is Jenkins username for authentication.
 
-* `password` - (Required) This is the Jenkins password for authentication. If you are using the GitHub OAuth authentication method, enter your Personal Access Token here.
+* `password` - (Optional) This is the Jenkins password for authentication. If you are using the GitHub OAuth authentication method, enter your Personal Access Token here.
 
 * `ca_cert` - (Optional) This is the path to the self-signed certificate that may be required in order to authenticate to your Jenkins instance.

--- a/jenkins/provider.go
+++ b/jenkins/provider.go
@@ -26,13 +26,13 @@ func Provider() *schema.Provider {
 			},
 			"username": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true, // Needs to be optional to be able to run terraform validate in CICD pipelines.
 				DefaultFunc: schema.EnvDefaultFunc("JENKINS_USERNAME", nil),
 				Description: "Username to authenticate to Jenkins.",
 			},
 			"password": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true, // Needs to be optional to be able to run terraform validate in CICD pipelines.
 				DefaultFunc: schema.EnvDefaultFunc("JENKINS_PASSWORD", nil),
 				Description: "Password to authenticate to Jenkins.",
 			},

--- a/jenkins/provider.go
+++ b/jenkins/provider.go
@@ -26,13 +26,13 @@ func Provider() *schema.Provider {
 			},
 			"username": {
 				Type:        schema.TypeString,
-				Optional:    true, // Needs to be optional to be able to run terraform validate in CICD pipelines.
+				Optional:    true, // Needs to be optional to be able to run terraform validate without providing credentials
 				DefaultFunc: schema.EnvDefaultFunc("JENKINS_USERNAME", nil),
 				Description: "Username to authenticate to Jenkins.",
 			},
 			"password": {
 				Type:        schema.TypeString,
-				Optional:    true, // Needs to be optional to be able to run terraform validate in CICD pipelines.
+				Optional:    true, // Needs to be optional to be able to run terraform validate without providing credentials
 				DefaultFunc: schema.EnvDefaultFunc("JENKINS_PASSWORD", nil),
 				Description: "Password to authenticate to Jenkins.",
 			},


### PR DESCRIPTION
This PR will set the `username` and `password` to be optional to be able to run `terraform validate` without providing any credentials i.e. in CI/CD pipelines.

This will fix [issue 125](https://github.com/taiidani/terraform-provider-jenkins/issues/125)