### PR TITLE
Update docs to include how to import secret text resource

### DIFF
--- a/docs/resources/credential_secret_text.md
+++ b/docs/resources/credential_secret_text.md
@@ -25,3 +25,11 @@ The following arguments are supported:
 ## Attribute Reference
 
 All arguments above are exported.
+
+## Import
+
+Secret text credential may be imported by their canonical name, e.g.
+
+```sh
+$ terraform import jenkins_credential_secret_text.example "[<folder>/]<domain>/<name>"
+```


### PR DESCRIPTION
This PR will add information on how to import `jenkins_credential_secret_text`.

This will fix https://github.com/taiidani/terraform-provider-jenkins/issues/122