### PR TITLE
Migrate acceptance tests to new testing framework

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,11 @@ go 1.19
 require (
 	github.com/bndr/gojenkins v1.1.1-0.20210407143218-9e2483ff7ebd
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
+	github.com/hashicorp/terraform-plugin-framework v1.3.2
+	github.com/hashicorp/terraform-plugin-go v0.18.0
+	github.com/hashicorp/terraform-plugin-mux v0.11.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.27.0
+	github.com/hashicorp/terraform-plugin-testing v1.3.0
 )
 
 require (
@@ -29,11 +33,7 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.18.1 // indirect
 	github.com/hashicorp/terraform-json v0.17.0 // indirect
-	github.com/hashicorp/terraform-plugin-framework v1.3.2 // indirect
-	github.com/hashicorp/terraform-plugin-go v0.18.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
-	github.com/hashicorp/terraform-plugin-mux v0.11.2 // indirect
-	github.com/hashicorp/terraform-plugin-testing v1.3.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.1 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,10 +64,6 @@ github.com/hashicorp/terraform-json v0.17.0 h1:EiA1Wp07nknYQAiv+jIt4dX4Cq5crgP+T
 github.com/hashicorp/terraform-json v0.17.0/go.mod h1:Huy6zt6euxaY9knPAFKjUITn8QxUFIe9VuSzb4zn/0o=
 github.com/hashicorp/terraform-plugin-framework v1.3.2 h1:aQ6GSD0CTnvoALEWvKAkcH/d8jqSE0Qq56NYEhCexUs=
 github.com/hashicorp/terraform-plugin-framework v1.3.2/go.mod h1:oimsRAPJOYkZ4kY6xIGfR0PHjpHLDLaknzuptl6AvnY=
-github.com/hashicorp/terraform-plugin-go v0.16.0 h1:DSOQ0rz5FUiVO4NUzMs8ln9gsPgHMTsfns7Nk+6gPuE=
-github.com/hashicorp/terraform-plugin-go v0.16.0/go.mod h1:4sn8bFuDbt+2+Yztt35IbOrvZc0zyEi87gJzsTgCES8=
-github.com/hashicorp/terraform-plugin-go v0.17.0 h1:OpqgPLvjW3vCDA9VUEmRKppCZOG/+Vkdp6ijkG8aJek=
-github.com/hashicorp/terraform-plugin-go v0.17.0/go.mod h1:l7VK+2u5Kf2y+A+742GX0ouLut3gttudmvMgN0PA74Y=
 github.com/hashicorp/terraform-plugin-go v0.18.0 h1:IwTkOS9cOW1ehLd/rG0y+u/TGLK9y6fGoBjXVUquzpE=
 github.com/hashicorp/terraform-plugin-go v0.18.0/go.mod h1:l7VK+2u5Kf2y+A+742GX0ouLut3gttudmvMgN0PA74Y=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=
@@ -170,14 +166,10 @@ google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 h1:KpwkzHKEF7B9Zxg18WzOa7djJ+Ha5DzthMyZYQfEn2A=
 google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1/go.mod h1:nKE/iIaLqn2bQwXBg8f1g2Ylh6r5MN5CmZvuzZCgsCU=
-google.golang.org/grpc v1.56.0 h1:+y7Bs8rtMd07LeXmL3NxcTLn7mUkbKZqEpPhMNkwJEE=
-google.golang.org/grpc v1.56.0/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpXqQ9s=
 google.golang.org/grpc v1.56.1 h1:z0dNfjIl0VpaZ9iSVjA6daGatAYwPGstTjt5vkRMFkQ=
 google.golang.org/grpc v1.56.1/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpXqQ9s=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
-google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/jenkins/data_source_jenkins_credential_username_test.go
+++ b/jenkins/data_source_jenkins_credential_username_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccJenkinsCredentialUsernameDataSource_basic(t *testing.T) {

--- a/jenkins/data_source_jenkins_credential_vault_approle_test.go
+++ b/jenkins/data_source_jenkins_credential_vault_approle_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccJenkinsCredentialVaultAppRoleDataSource_basic(t *testing.T) {

--- a/jenkins/data_source_jenkins_folder_test.go
+++ b/jenkins/data_source_jenkins_folder_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccJenkinsFolderDataSource_basic(t *testing.T) {

--- a/jenkins/data_source_jenkins_job_test.go
+++ b/jenkins/data_source_jenkins_job_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccJenkinsJobDataSource_basic(t *testing.T) {

--- a/jenkins/resource_jenkins_credential_azure_service_principal_test.go
+++ b/jenkins/resource_jenkins_credential_azure_service_principal_test.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccJenkinsCredentialAzureServicePrincipal_basic(t *testing.T) {
@@ -22,7 +22,7 @@ func TestAccJenkinsCredentialAzureServicePrincipal_basic(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: `			  
+				Config: `
 				resource jenkins_credential_azure_service_principal foo {
 					name = "bla"
 					description = "blabla"
@@ -63,7 +63,7 @@ func TestAccJenkinsCredentialAzureServicePrincipal_folder(t *testing.T) {
 					name        = "azure-service-principal-test-folder-%s"
 					description = "A sample folder"
 				}
-				  
+
 				resource jenkins_credential_azure_service_principal foo {
 					name = "bla"
 					folder = jenkins_folder.example.id
@@ -86,7 +86,7 @@ func TestAccJenkinsCredentialAzureServicePrincipal_folder(t *testing.T) {
 					name        = "azure-service-principal-test-folder-%s"
 					description = "A sample folder"
 				}
-				  
+
 				resource jenkins_credential_azure_service_principal foo {
 					name = "bla"
 					folder = jenkins_folder.example.id
@@ -125,7 +125,7 @@ func TestAccJenkinsCredentialAzureServicePrincipal_folder_certificate(t *testing
 					name        = "azure-service-principal-test-folder-%s"
 					description = "A sample folder"
 				}
-				  
+
 				resource jenkins_credential_azure_service_principal foo {
 					name = "bla"
 					folder = jenkins_folder.example.id
@@ -147,7 +147,7 @@ func TestAccJenkinsCredentialAzureServicePrincipal_folder_certificate(t *testing
 					name        = "azure-service-principal-test-folder-%s"
 					description = "A sample folder"
 				}
-				  
+
 				resource jenkins_credential_azure_service_principal foo {
 					name = "bla"
 					folder = jenkins_folder.example.id

--- a/jenkins/resource_jenkins_credential_secret_file_test.go
+++ b/jenkins/resource_jenkins_credential_secret_file_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	jenkins "github.com/bndr/gojenkins"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccJenkinsCredentialSecretFile_basic(t *testing.T) {
@@ -23,7 +23,7 @@ func TestAccJenkinsCredentialSecretFile_basic(t *testing.T) {
 				Config: `
 				resource jenkins_credential_secret_file foo {
 				  name = "test-secret-file"
-				  filename = "secret.txt"             
+				  filename = "secret.txt"
 				  secretbytes = base64encode("This is a test.")
 				}`,
 				Check: resource.ComposeTestCheckFunc(
@@ -36,7 +36,7 @@ func TestAccJenkinsCredentialSecretFile_basic(t *testing.T) {
 				Config: `
 				resource jenkins_credential_secret_file foo {
 				  name = "test-secret-file"
-				  filename = "secret.txt"             
+				  filename = "secret.txt"
 				  secretbytes = base64encode("This is a new secret content.")
 				}`,
 				// In comparison below I use already base64 encoded value of: VGhpcyBpcyBhIG5ldyBzZWNyZXQgY29udGVudC4=
@@ -77,7 +77,7 @@ func TestAccJenkinsCredentialSecretFile_folder(t *testing.T) {
 				resource jenkins_credential_secret_file foo {
 					name = "test-secret-file"
 					folder = jenkins_folder.foo_sub.id
-					filename = "secret.txt"             
+					filename = "secret.txt"
 					secretbytes = "VGhpcyBpcyBhIHRlc3Qu"
 				}`, randString),
 				Check: resource.ComposeTestCheckFunc(
@@ -111,7 +111,7 @@ func TestAccJenkinsCredentialSecretFile_folder(t *testing.T) {
 					name = "test-secret-file"
 					folder = jenkins_folder.foo_sub.id
 					description = "new-description"
-                                        filename = "secret.txt"             
+                                        filename = "secret.txt"
                                         secretbytes = "VGhpcyBpcyBhIHRlc3Qu"
 
 				}`, randString),

--- a/jenkins/resource_jenkins_credential_secret_text_test.go
+++ b/jenkins/resource_jenkins_credential_secret_text_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	jenkins "github.com/bndr/gojenkins"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccJenkinsCredentialSecretText_basic(t *testing.T) {

--- a/jenkins/resource_jenkins_credential_ssh_test.go
+++ b/jenkins/resource_jenkins_credential_ssh_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	jenkins "github.com/bndr/gojenkins"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccJenkinsCredentialSSH_basic(t *testing.T) {

--- a/jenkins/resource_jenkins_credential_username_test.go
+++ b/jenkins/resource_jenkins_credential_username_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	jenkins "github.com/bndr/gojenkins"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccJenkinsCredentialUsername_basic(t *testing.T) {

--- a/jenkins/resource_jenkins_credential_vault_approle_test.go
+++ b/jenkins/resource_jenkins_credential_vault_approle_test.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccJenkinsCredentialVaultAppRole_basic(t *testing.T) {

--- a/jenkins/resource_jenkins_folder_test.go
+++ b/jenkins/resource_jenkins_folder_test.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccJenkinsFolder_basic(t *testing.T) {

--- a/jenkins/resource_jenkins_job_test.go
+++ b/jenkins/resource_jenkins_job_test.go
@@ -12,10 +12,10 @@ import (
 
 	jenkins "github.com/bndr/gojenkins"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 var (


### PR DESCRIPTION
# What Is Changing

Migrating acceptance tests from the SDKv2 implementations to the new Testing framework, via https://developer.hashicorp.com/terraform/plugin/testing/migrating.

# Test Steps

- [x] Have you updated the `docs/` folder to match your change?
- [x] Have you exercised your change using the `examples/` docker compose setup?

```sh
make testacc
```

<!-- Additional test steps beyond the acceptance tests go here. -->
