### PR TITLE
Add mux to all acceptance tests, forward compatibility

### DIFF
--- a/jenkins/data_source_jenkins_credential_username_test.go
+++ b/jenkins/data_source_jenkins_credential_username_test.go
@@ -12,8 +12,8 @@ func TestAccJenkinsCredentialUsernameDataSource_basic(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -44,8 +44,8 @@ func TestAccJenkinsCredentialUsernameDataSource_nested(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`

--- a/jenkins/data_source_jenkins_credential_vault_approle_test.go
+++ b/jenkins/data_source_jenkins_credential_vault_approle_test.go
@@ -12,8 +12,8 @@ func TestAccJenkinsCredentialVaultAppRoleDataSource_basic(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -44,8 +44,8 @@ func TestAccJenkinsCredentialVaultAppRoleDataSource_nested(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -83,8 +83,8 @@ func TestAccJenkinsCredentialVaultAppRoleDataSource_basic_namespaced(t *testing.
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -117,8 +117,8 @@ func TestAccJenkinsCredentialVaultAppRoleDataSource_nested_namespaced(t *testing
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`

--- a/jenkins/data_source_jenkins_folder_test.go
+++ b/jenkins/data_source_jenkins_folder_test.go
@@ -12,8 +12,8 @@ func TestAccJenkinsFolderDataSource_basic(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -42,8 +42,8 @@ func TestAccJenkinsFolderDataSource_nested(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`

--- a/jenkins/data_source_jenkins_job_test.go
+++ b/jenkins/data_source_jenkins_job_test.go
@@ -17,8 +17,8 @@ func TestAccJenkinsJobDataSource_basic(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -49,8 +49,8 @@ func TestAccJenkinsJobDataSource_nested(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`

--- a/jenkins/provider_framework.go
+++ b/jenkins/provider_framework.go
@@ -116,6 +116,7 @@ func (p *JenkinsProvider) Configure(ctx context.Context, req provider.ConfigureR
 		)
 	}
 	resp.ResourceData = client
+	resp.DataSourceData = client
 }
 
 // DataSources satisfies the provider.Provider interface for JenkinsProvider.

--- a/jenkins/resource_jenkins_credential_azure_service_principal_test.go
+++ b/jenkins/resource_jenkins_credential_azure_service_principal_test.go
@@ -14,8 +14,8 @@ func TestAccJenkinsCredentialAzureServicePrincipal_basic(t *testing.T) {
 	var cred AzureServicePrincipalCredentials
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccCheckJenkinsCredentialAzureServicePrincipalDestroy,
 			testAccCheckJenkinsFolderDestroy,
@@ -50,8 +50,8 @@ func TestAccJenkinsCredentialAzureServicePrincipal_folder(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccCheckJenkinsCredentialAzureServicePrincipalDestroy,
 			testAccCheckJenkinsFolderDestroy,
@@ -112,8 +112,8 @@ func TestAccJenkinsCredentialAzureServicePrincipal_folder_certificate(t *testing
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccCheckJenkinsCredentialAzureServicePrincipalDestroy,
 			testAccCheckJenkinsFolderDestroy,
@@ -169,7 +169,6 @@ func TestAccJenkinsCredentialAzureServicePrincipal_folder_certificate(t *testing
 
 func testAccCheckJenkinsCredentialAzureServicePrincipalExists(resourceName string, cred *AzureServicePrincipalCredentials) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(jenkinsClient)
 		ctx := context.Background()
 
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -181,7 +180,7 @@ func testAccCheckJenkinsCredentialAzureServicePrincipalExists(resourceName strin
 			return fmt.Errorf("ID is not set")
 		}
 
-		manager := client.Credentials()
+		manager := testAccClient.Credentials()
 		manager.Folder = formatFolderName(rs.Primary.Attributes["folder"])
 		err := manager.GetSingle(ctx, rs.Primary.Attributes["domain"], rs.Primary.Attributes["name"], cred)
 		if err != nil {
@@ -193,7 +192,6 @@ func testAccCheckJenkinsCredentialAzureServicePrincipalExists(resourceName strin
 }
 
 func testAccCheckJenkinsCredentialAzureServicePrincipalDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(jenkinsClient)
 	ctx := context.Background()
 
 	for _, rs := range s.RootModule().Resources {
@@ -204,7 +202,7 @@ func testAccCheckJenkinsCredentialAzureServicePrincipalDestroy(s *terraform.Stat
 		}
 
 		cred := AzureServicePrincipalCredentials{}
-		manager := client.Credentials()
+		manager := testAccClient.Credentials()
 		manager.Folder = formatFolderName(rs.Primary.Meta["folder"].(string))
 		err := manager.GetSingle(ctx, rs.Primary.Meta["domain"].(string), rs.Primary.Meta["name"].(string), &cred)
 		if err == nil {

--- a/jenkins/resource_jenkins_credential_secret_file_test.go
+++ b/jenkins/resource_jenkins_credential_secret_file_test.go
@@ -15,9 +15,9 @@ func TestAccJenkinsCredentialSecretFile_basic(t *testing.T) {
 	var cred jenkins.FileCredentials
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckJenkinsCredentialSecretFileDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccCheckJenkinsCredentialSecretFileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: `
@@ -54,8 +54,8 @@ func TestAccJenkinsCredentialSecretFile_folder(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccCheckJenkinsCredentialSecretFileDestroy,
 			testAccCheckJenkinsFolderDestroy,
@@ -126,7 +126,6 @@ func TestAccJenkinsCredentialSecretFile_folder(t *testing.T) {
 
 func testAccCheckJenkinsCredentialSecretFileExists(resourceName string, cred *jenkins.FileCredentials) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(jenkinsClient)
 		ctx := context.Background()
 
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -138,7 +137,7 @@ func testAccCheckJenkinsCredentialSecretFileExists(resourceName string, cred *je
 			return fmt.Errorf("ID is not set")
 		}
 
-		manager := client.Credentials()
+		manager := testAccClient.Credentials()
 		manager.Folder = formatFolderName(rs.Primary.Attributes["folder"])
 		err := manager.GetSingle(ctx, rs.Primary.Attributes["domain"], rs.Primary.Attributes["name"], cred)
 		if err != nil {
@@ -150,7 +149,6 @@ func testAccCheckJenkinsCredentialSecretFileExists(resourceName string, cred *je
 }
 
 func testAccCheckJenkinsCredentialSecretFileDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(jenkinsClient)
 	ctx := context.Background()
 
 	for _, rs := range s.RootModule().Resources {
@@ -161,7 +159,7 @@ func testAccCheckJenkinsCredentialSecretFileDestroy(s *terraform.State) error {
 		}
 
 		cred := jenkins.FileCredentials{}
-		manager := client.Credentials()
+		manager := testAccClient.Credentials()
 		manager.Folder = formatFolderName(rs.Primary.Meta["folder"].(string))
 		err := manager.GetSingle(ctx, rs.Primary.Meta["domain"].(string), rs.Primary.Meta["name"].(string), &cred)
 		if err == nil {

--- a/jenkins/resource_jenkins_credential_secret_text_test.go
+++ b/jenkins/resource_jenkins_credential_secret_text_test.go
@@ -15,9 +15,9 @@ func TestAccJenkinsCredentialSecretText_basic(t *testing.T) {
 	var cred jenkins.StringCredentials
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckJenkinsCredentialSecretTextDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccCheckJenkinsCredentialSecretTextDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: `
@@ -52,8 +52,8 @@ func TestAccJenkinsCredentialSecretText_folder(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccCheckJenkinsCredentialSecretTextDestroy,
 			testAccCheckJenkinsFolderDestroy,
@@ -121,7 +121,6 @@ func TestAccJenkinsCredentialSecretText_folder(t *testing.T) {
 
 func testAccCheckJenkinsCredentialSecretTextExists(resourceName string, cred *jenkins.StringCredentials) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(jenkinsClient)
 		ctx := context.Background()
 
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -133,7 +132,7 @@ func testAccCheckJenkinsCredentialSecretTextExists(resourceName string, cred *je
 			return fmt.Errorf("ID is not set")
 		}
 
-		manager := client.Credentials()
+		manager := testAccClient.Credentials()
 		manager.Folder = formatFolderName(rs.Primary.Attributes["folder"])
 		err := manager.GetSingle(ctx, rs.Primary.Attributes["domain"], rs.Primary.Attributes["name"], cred)
 		if err != nil {
@@ -145,7 +144,6 @@ func testAccCheckJenkinsCredentialSecretTextExists(resourceName string, cred *je
 }
 
 func testAccCheckJenkinsCredentialSecretTextDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(jenkinsClient)
 	ctx := context.Background()
 
 	for _, rs := range s.RootModule().Resources {
@@ -156,7 +154,7 @@ func testAccCheckJenkinsCredentialSecretTextDestroy(s *terraform.State) error {
 		}
 
 		cred := jenkins.StringCredentials{}
-		manager := client.Credentials()
+		manager := testAccClient.Credentials()
 		manager.Folder = formatFolderName(rs.Primary.Meta["folder"].(string))
 		err := manager.GetSingle(ctx, rs.Primary.Meta["domain"].(string), rs.Primary.Meta["name"].(string), &cred)
 		if err == nil {

--- a/jenkins/resource_jenkins_credential_ssh_test.go
+++ b/jenkins/resource_jenkins_credential_ssh_test.go
@@ -15,9 +15,9 @@ func TestAccJenkinsCredentialSSH_basic(t *testing.T) {
 	var cred jenkins.SSHCredentials
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckJenkinsCredentialSSHDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccCheckJenkinsCredentialSSHDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: `
@@ -67,8 +67,8 @@ func TestAccJenkinsCredentialSSH_folder(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccCheckJenkinsCredentialSSHDestroy,
 			testAccCheckJenkinsFolderDestroy,
@@ -172,7 +172,6 @@ func TestAccJenkinsCredentialSSH_folder(t *testing.T) {
 
 func testAccCheckJenkinsCredentialSSHExists(resourceName string, cred *jenkins.SSHCredentials) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(jenkinsClient)
 		ctx := context.Background()
 
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -184,7 +183,7 @@ func testAccCheckJenkinsCredentialSSHExists(resourceName string, cred *jenkins.S
 			return fmt.Errorf("ID is not set")
 		}
 
-		manager := client.Credentials()
+		manager := testAccClient.Credentials()
 		manager.Folder = formatFolderName(rs.Primary.Attributes["folder"])
 		err := manager.GetSingle(ctx, rs.Primary.Attributes["domain"], rs.Primary.Attributes["name"], cred)
 		if err != nil {
@@ -196,7 +195,6 @@ func testAccCheckJenkinsCredentialSSHExists(resourceName string, cred *jenkins.S
 }
 
 func testAccCheckJenkinsCredentialSSHDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(jenkinsClient)
 	ctx := context.Background()
 
 	for _, rs := range s.RootModule().Resources {
@@ -207,7 +205,7 @@ func testAccCheckJenkinsCredentialSSHDestroy(s *terraform.State) error {
 		}
 
 		cred := jenkins.SSHCredentials{}
-		manager := client.Credentials()
+		manager := testAccClient.Credentials()
 		manager.Folder = formatFolderName(rs.Primary.Meta["folder"].(string))
 		err := manager.GetSingle(ctx, rs.Primary.Meta["domain"].(string), rs.Primary.Meta["name"].(string), &cred)
 		if err == nil {

--- a/jenkins/resource_jenkins_credential_username_test.go
+++ b/jenkins/resource_jenkins_credential_username_test.go
@@ -15,9 +15,9 @@ func TestAccJenkinsCredentialUsername_basic(t *testing.T) {
 	var cred jenkins.UsernameCredentials
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckJenkinsCredentialUsernameDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccCheckJenkinsCredentialUsernameDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: `
@@ -54,8 +54,8 @@ func TestAccJenkinsCredentialUsername_folder(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccCheckJenkinsCredentialUsernameDestroy,
 			testAccCheckJenkinsFolderDestroy,
@@ -125,7 +125,6 @@ func TestAccJenkinsCredentialUsername_folder(t *testing.T) {
 
 func testAccCheckJenkinsCredentialUsernameExists(resourceName string, cred *jenkins.UsernameCredentials) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(jenkinsClient)
 		ctx := context.Background()
 
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -137,7 +136,7 @@ func testAccCheckJenkinsCredentialUsernameExists(resourceName string, cred *jenk
 			return fmt.Errorf("ID is not set")
 		}
 
-		manager := client.Credentials()
+		manager := testAccClient.Credentials()
 		manager.Folder = formatFolderName(rs.Primary.Attributes["folder"])
 		err := manager.GetSingle(ctx, rs.Primary.Attributes["domain"], rs.Primary.Attributes["name"], cred)
 		if err != nil {
@@ -149,7 +148,6 @@ func testAccCheckJenkinsCredentialUsernameExists(resourceName string, cred *jenk
 }
 
 func testAccCheckJenkinsCredentialUsernameDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(jenkinsClient)
 	ctx := context.Background()
 
 	for _, rs := range s.RootModule().Resources {
@@ -160,7 +158,7 @@ func testAccCheckJenkinsCredentialUsernameDestroy(s *terraform.State) error {
 		}
 
 		cred := jenkins.UsernameCredentials{}
-		manager := client.Credentials()
+		manager := testAccClient.Credentials()
 		manager.Folder = formatFolderName(rs.Primary.Meta["folder"].(string))
 		err := manager.GetSingle(ctx, rs.Primary.Meta["domain"].(string), rs.Primary.Meta["name"].(string), &cred)
 		if err == nil {

--- a/jenkins/resource_jenkins_credential_vault_approle_test.go
+++ b/jenkins/resource_jenkins_credential_vault_approle_test.go
@@ -14,9 +14,9 @@ func TestAccJenkinsCredentialVaultAppRole_basic(t *testing.T) {
 	var cred VaultAppRoleCredentials
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckJenkinsCredentialVaultAppRoleDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccCheckJenkinsCredentialVaultAppRoleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: `
@@ -52,9 +52,9 @@ func TestAccJenkinsCredentialVaultAppRole_basic_namespaced(t *testing.T) {
 	var cred VaultAppRoleCredentials
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckJenkinsCredentialVaultAppRoleDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccCheckJenkinsCredentialVaultAppRoleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: `
@@ -93,8 +93,8 @@ func TestAccJenkinsCredentialVaultAppRole_folder_namespaced(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccCheckJenkinsCredentialVaultAppRoleDestroy,
 			testAccCheckJenkinsFolderDestroy,
@@ -177,8 +177,8 @@ func TestAccJenkinsCredentialVaultAppRole_folder(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccCheckJenkinsCredentialVaultAppRoleDestroy,
 			testAccCheckJenkinsFolderDestroy,
@@ -256,7 +256,6 @@ func TestAccJenkinsCredentialVaultAppRole_folder(t *testing.T) {
 
 func testAccCheckJenkinsCredentialVaultAppRoleExists(resourceName string, cred *VaultAppRoleCredentials) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(jenkinsClient)
 		ctx := context.Background()
 
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -268,7 +267,7 @@ func testAccCheckJenkinsCredentialVaultAppRoleExists(resourceName string, cred *
 			return fmt.Errorf("ID is not set")
 		}
 
-		manager := client.Credentials()
+		manager := testAccClient.Credentials()
 		manager.Folder = formatFolderName(rs.Primary.Attributes["folder"])
 		err := manager.GetSingle(ctx, rs.Primary.Attributes["domain"], rs.Primary.Attributes["name"], cred)
 		if err != nil {
@@ -280,7 +279,6 @@ func testAccCheckJenkinsCredentialVaultAppRoleExists(resourceName string, cred *
 }
 
 func testAccCheckJenkinsCredentialVaultAppRoleDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(jenkinsClient)
 	ctx := context.Background()
 
 	for _, rs := range s.RootModule().Resources {
@@ -291,7 +289,7 @@ func testAccCheckJenkinsCredentialVaultAppRoleDestroy(s *terraform.State) error 
 		}
 
 		cred := VaultAppRoleCredentials{}
-		manager := client.Credentials()
+		manager := testAccClient.Credentials()
 		manager.Folder = formatFolderName(rs.Primary.Meta["folder"].(string))
 		err := manager.GetSingle(ctx, rs.Primary.Meta["domain"].(string), rs.Primary.Meta["name"].(string), &cred)
 		if err == nil {

--- a/jenkins/resource_jenkins_folder_test.go
+++ b/jenkins/resource_jenkins_folder_test.go
@@ -14,9 +14,9 @@ func TestAccJenkinsFolder_basic(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckJenkinsFolderDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccCheckJenkinsFolderDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -38,9 +38,9 @@ func TestAccJenkinsFolder_withDisplayName(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckJenkinsFolderDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccCheckJenkinsFolderDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -63,9 +63,9 @@ func TestAccJenkinsFolder_nested(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckJenkinsFolderDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccCheckJenkinsFolderDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -94,7 +94,6 @@ func TestAccJenkinsFolder_nested(t *testing.T) {
 }
 
 func testAccCheckJenkinsFolderDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(jenkinsClient)
 	ctx := context.Background()
 
 	for _, rs := range s.RootModule().Resources {
@@ -102,7 +101,7 @@ func testAccCheckJenkinsFolderDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := client.GetJob(ctx, rs.Primary.ID)
+		_, err := testAccClient.GetJob(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Folder %s still exists", rs.Primary.ID)
 		}

--- a/jenkins/resource_jenkins_job_test.go
+++ b/jenkins/resource_jenkins_job_test.go
@@ -35,9 +35,9 @@ func TestAccJenkinsJob_basic(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckJenkinsJobDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccCheckJenkinsJobDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -61,9 +61,9 @@ func TestAccJenkinsJob_basic_parameterized(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckJenkinsJobDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccCheckJenkinsJobDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -93,9 +93,9 @@ func TestAccJenkinsJob_nested(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckJenkinsFolderDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccCheckJenkinsFolderDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -128,9 +128,9 @@ func TestAccJenkinsJob_nested_parameterized(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckJenkinsFolderDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccCheckJenkinsFolderDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -164,7 +164,6 @@ parameters = {
 }
 
 func testAccCheckJenkinsJobDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(jenkinsClient)
 	ctx := context.Background()
 
 	for _, rs := range s.RootModule().Resources {
@@ -172,7 +171,7 @@ func testAccCheckJenkinsJobDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := client.GetJob(ctx, rs.Primary.ID)
+		_, err := testAccClient.GetJob(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Job %s still exists", rs.Primary.ID)
 		}


### PR DESCRIPTION
# What Is Changing

Muxing the providers for all acceptance tests and removing any SDK-specific logic. This should allow migration of the resources/data sources without updating the tests.

# Test Steps

- [x] Have you updated the `docs/` folder to match your change?
- [x] Have you exercised your change using the `examples/` docker compose setup?

```sh
make testacc
```

<!-- Additional test steps beyond the acceptance tests go here. -->
