### PR TITLE
Bump Go to 1.20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      combined:
+      gha:
         patterns: ["*"]
 
   - package-ecosystem: "gomod"
@@ -13,7 +13,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      combined:
+      gomod:
         patterns: ["*"]
 
   - package-ecosystem: "gomod"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           skip-pkg-cache: true
           skip-build-cache: true
+          args: --timeout=10m
 
   unit:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# Terraform Provider
+# Jenkins Terraform Provider
 
-![Unit Tests](https://github.com/taiidani/terraform-provider-jenkins/workflows/Unit%20Tests/badge.svg)
-![Acceptance Tests](https://github.com/taiidani/terraform-provider-jenkins/workflows/Acceptance%20Tests/badge.svg)
+[![test](https://github.com/taiidani/terraform-provider-jenkins/actions/workflows/test.yml/badge.svg)](https://github.com/taiidani/terraform-provider-jenkins/actions/workflows/test.yml)
 
 - Website: https://www.terraform.io
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/taiidani/terraform-provider-jenkins
 
-go 1.19
+go 1.20
 
 require (
 	github.com/bndr/gojenkins v1.1.1-0.20210407143218-9e2483ff7ebd


### PR DESCRIPTION
# What Is Changing

Bumping Go to version 1.20, alongside a small assortment of quality of life improvements.

# Test Steps

- [x] If you've changed documentation, have you run `make generate` to render the `docs/` folder?
- [x] Have you updated the `integration/` tests with a [terraform test](https://developer.hashicorp.com/terraform/language/tests) compatible change?

<!-- Additional test steps go here. -->
