### PR TITLE
Reduce code duplication in Framework

### DIFF
--- a/jenkins/data_source.go
+++ b/jenkins/data_source.go
@@ -1,0 +1,76 @@
+package jenkins
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+)
+
+type (
+	// dataSourceHelper provides assistive snippets of logic to help reduce duplication in
+	// each data source definition.
+	dataSourceHelper struct {
+		client *jenkinsAdapter
+	}
+)
+
+func newDataSourceHelper() *dataSourceHelper {
+	return &dataSourceHelper{}
+}
+
+// Configure should register the client for the resource.
+func (d *dataSourceHelper) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*jenkinsAdapter)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *jenkinsAdapter, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.client = client
+}
+
+func (d *dataSourceHelper) schema(s map[string]schema.Attribute) map[string]schema.Attribute {
+	s["id"] = schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: "The full canonical job path, e.g. `/job/job-name`",
+	}
+	s["name"] = schema.StringAttribute{
+		Required:            true,
+		MarkdownDescription: "The name of the resource being read.",
+	}
+	s["folder"] = schema.StringAttribute{
+		MarkdownDescription: "The folder namespace containing this resource.",
+		Optional:            true,
+	}
+	s["description"] = schema.StringAttribute{
+		MarkdownDescription: "A human readable description of the credentials being stored.",
+		Computed:            true,
+	}
+
+	return s
+}
+
+func (d *dataSourceHelper) schemaCredential(s map[string]schema.Attribute) map[string]schema.Attribute {
+	s = d.schema(s)
+	s["domain"] = schema.StringAttribute{
+		MarkdownDescription: "The domain store containing this resource.",
+		Optional:            true,
+	}
+	s["scope"] = schema.StringAttribute{
+		MarkdownDescription: `The visibility of the credentials to Jenkins agents. This will be either "GLOBAL" or "SYSTEM".`,
+		Computed:            true,
+	}
+
+	return s
+}

--- a/jenkins/data_source_jenkins_credential_username.go
+++ b/jenkins/data_source_jenkins_credential_username.go
@@ -2,7 +2,6 @@ package jenkins
 
 import (
 	"context"
-	"fmt"
 
 	jenkins "github.com/bndr/gojenkins"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -14,81 +13,39 @@ import (
 type credentialUsernameDataSourceModel struct {
 	ID          types.String `tfsdk:"id"`
 	Name        types.String `tfsdk:"name"`
-	Domain      types.String `tfsdk:"domain"`
 	Folder      types.String `tfsdk:"folder"`
-	Scope       types.String `tfsdk:"scope"`
 	Description types.String `tfsdk:"description"`
+	Domain      types.String `tfsdk:"domain"`
+	Scope       types.String `tfsdk:"scope"`
 	Username    types.String `tfsdk:"username"`
 }
 
 type credentialUsernameDataSource struct {
-	client *jenkinsAdapter
+	*dataSourceHelper
 }
 
 // Ensure the implementation satisfies the desired interfaces.
 var _ datasource.DataSourceWithConfigure = &credentialUsernameDataSource{}
 
 func newCredentialUsernameDataSource() datasource.DataSource {
-	return &credentialUsernameDataSource{}
+	return &credentialUsernameDataSource{
+		dataSourceHelper: newDataSourceHelper(),
+	}
 }
 
 func (d *credentialUsernameDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_credential_username"
 }
 
-// Configure should register the client for the resource.
-func (d *credentialUsernameDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	// Prevent panic if the provider has not been configured.
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*jenkinsAdapter)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *jenkinsAdapter, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	d.client = client
-}
-
 func (d *credentialUsernameDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Get the attributes of a username credential within Jenkins.",
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "The full canonical job path, e.g. `/job/job-name`",
-			},
-			"name": schema.StringAttribute{
-				Required:            true,
-				MarkdownDescription: "The name of the resource being read.",
-			},
-			"domain": schema.StringAttribute{
-				MarkdownDescription: "The domain store containing this resource.",
-				Optional:            true,
-			},
-			"folder": schema.StringAttribute{
-				MarkdownDescription: "The folder namespace containing this resource.",
-				Optional:            true,
-			},
-			"scope": schema.StringAttribute{
-				MarkdownDescription: `The visibility of the credentials to Jenkins agents. This will be either "GLOBAL" or "SYSTEM".`,
-				Computed:            true,
-			},
-			"description": schema.StringAttribute{
-				MarkdownDescription: "A human readable description of the credentials being stored.",
-				Computed:            true,
-			},
+		Attributes: d.schemaCredential(map[string]schema.Attribute{
 			"username": schema.StringAttribute{
 				MarkdownDescription: "The username associated with the credentials.",
 				Computed:            true,
 			},
-		},
+		}),
 	}
 }
 

--- a/jenkins/data_source_jenkins_credential_username.go
+++ b/jenkins/data_source_jenkins_credential_username.go
@@ -105,7 +105,7 @@ func (d *credentialUsernameDataSource) Read(ctx context.Context, req datasource.
 	cm.Folder = formatFolderName(data.Folder.ValueString())
 
 	if data.Domain.IsNull() {
-		data.Domain = basetypes.NewStringValue(defaultValueDomain)
+		data.Domain = basetypes.NewStringValue(defaultCredentialDomain)
 	}
 
 	cred := jenkins.UsernameCredentials{}

--- a/jenkins/data_source_jenkins_credential_username_test.go
+++ b/jenkins/data_source_jenkins_credential_username_test.go
@@ -26,7 +26,7 @@ func TestAccJenkinsCredentialUsernameDataSource_basic(t *testing.T) {
 
 				data jenkins_credential_username foo {
 					name   = jenkins_credential_username.foo.name
-					domain = "_"
+					domain = "`+defaultCredentialDomain+`"
 				}`, randString, randString),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("jenkins_credential_username.foo", "id", "/tf-acc-test-"+randString),
@@ -63,7 +63,7 @@ func TestAccJenkinsCredentialUsernameDataSource_nested(t *testing.T) {
 
 				data jenkins_credential_username sub {
 					name   = jenkins_credential_username.sub.name
-					domain = "_"
+					domain = "`+defaultCredentialDomain+`"
 					folder = jenkins_credential_username.sub.folder
 				}`, randString, randString),
 				Check: resource.ComposeTestCheckFunc(

--- a/jenkins/data_source_jenkins_credential_vault_approle.go
+++ b/jenkins/data_source_jenkins_credential_vault_approle.go
@@ -2,7 +2,6 @@ package jenkins
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -13,78 +12,36 @@ import (
 type credentialVaultAppRoleDataSourceModel struct {
 	ID          types.String `tfsdk:"id"`
 	Name        types.String `tfsdk:"name"`
-	Domain      types.String `tfsdk:"domain"`
 	Folder      types.String `tfsdk:"folder"`
-	Scope       types.String `tfsdk:"scope"`
 	Description types.String `tfsdk:"description"`
+	Domain      types.String `tfsdk:"domain"`
+	Scope       types.String `tfsdk:"scope"`
 	Namespace   types.String `tfsdk:"namespace"`
 	Path        types.String `tfsdk:"path"`
 	RoleID      types.String `tfsdk:"role_id"`
 }
 
 type credentialVaultAppRoleDataSource struct {
-	client *jenkinsAdapter
+	*dataSourceHelper
 }
 
 // Ensure the implementation satisfies the desired interfaces.
 var _ datasource.DataSourceWithConfigure = &credentialVaultAppRoleDataSource{}
 
 func newCredentialVaultAppRoleDataSource() datasource.DataSource {
-	return &credentialVaultAppRoleDataSource{}
+	return &credentialVaultAppRoleDataSource{
+		dataSourceHelper: newDataSourceHelper(),
+	}
 }
 
 func (d *credentialVaultAppRoleDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_credential_vault_approle"
 }
 
-// Configure should register the client for the resource.
-func (d *credentialVaultAppRoleDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	// Prevent panic if the provider has not been configured.
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*jenkinsAdapter)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *jenkinsAdapter, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	d.client = client
-}
-
 func (d *credentialVaultAppRoleDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Get the attributes of a vault approle credential within Jenkins.",
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "The full canonical job path, e.g. `/job/job-name`",
-			},
-			"name": schema.StringAttribute{
-				Required:            true,
-				MarkdownDescription: "The name of the resource being read.",
-			},
-			"domain": schema.StringAttribute{
-				MarkdownDescription: "The domain store containing this resource.",
-				Optional:            true,
-			},
-			"folder": schema.StringAttribute{
-				MarkdownDescription: "The folder namespace containing this resource.",
-				Optional:            true,
-			},
-			"scope": schema.StringAttribute{
-				MarkdownDescription: `The visibility of the credentials to Jenkins agents. This will be either "GLOBAL" or "SYSTEM".`,
-				Computed:            true,
-			},
-			"description": schema.StringAttribute{
-				MarkdownDescription: "A human readable description of the credentials being stored.",
-				Computed:            true,
-			},
+		Attributes: d.schemaCredential(map[string]schema.Attribute{
 			"namespace": schema.StringAttribute{
 				MarkdownDescription: "The Vault namespace of the approle credential.",
 				Computed:            true,
@@ -97,7 +54,7 @@ func (d *credentialVaultAppRoleDataSource) Schema(ctx context.Context, req datas
 				MarkdownDescription: "The role_id associated with the credentials.",
 				Computed:            true,
 			},
-		},
+		}),
 	}
 }
 

--- a/jenkins/data_source_jenkins_credential_vault_approle.go
+++ b/jenkins/data_source_jenkins_credential_vault_approle.go
@@ -114,7 +114,7 @@ func (d *credentialVaultAppRoleDataSource) Read(ctx context.Context, req datasou
 	cm.Folder = formatFolderName(data.Folder.ValueString())
 
 	if data.Domain.IsNull() {
-		data.Domain = basetypes.NewStringValue(defaultValueDomain)
+		data.Domain = basetypes.NewStringValue(defaultCredentialDomain)
 	}
 
 	cred := VaultAppRoleCredentials{}

--- a/jenkins/data_source_jenkins_credential_vault_approle_test.go
+++ b/jenkins/data_source_jenkins_credential_vault_approle_test.go
@@ -26,7 +26,7 @@ func TestAccJenkinsCredentialVaultAppRoleDataSource_basic(t *testing.T) {
 
 				data jenkins_credential_vault_approle foo {
 					name   = jenkins_credential_vault_approle.foo.name
-					domain = "_"
+					domain = "`+defaultCredentialDomain+`"
 				}`, randString, randString),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("jenkins_credential_vault_approle.foo", "id", "/tf-acc-test-"+randString),
@@ -63,7 +63,7 @@ func TestAccJenkinsCredentialVaultAppRoleDataSource_nested(t *testing.T) {
 
 				data jenkins_credential_vault_approle sub {
 					name   = jenkins_credential_vault_approle.sub.name
-					domain = "_"
+					domain = "`+defaultCredentialDomain+`"
 					folder = jenkins_credential_vault_approle.sub.folder
 				}`, randString, randString),
 				Check: resource.ComposeTestCheckFunc(
@@ -98,7 +98,7 @@ func TestAccJenkinsCredentialVaultAppRoleDataSource_basic_namespaced(t *testing.
 
 				data jenkins_credential_vault_approle foo {
 					name   = jenkins_credential_vault_approle.foo.name
-					domain = "_"
+					domain = "`+defaultCredentialDomain+`"
 				}`, randString, randString),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("jenkins_credential_vault_approle.foo", "id", "/tf-acc-test-"+randString),
@@ -137,7 +137,7 @@ func TestAccJenkinsCredentialVaultAppRoleDataSource_nested_namespaced(t *testing
 
 				data jenkins_credential_vault_approle sub {
 					name   = jenkins_credential_vault_approle.sub.name
-					domain = "_"
+					domain = "`+defaultCredentialDomain+`"
 					folder = jenkins_credential_vault_approle.sub.folder
 				}`, randString, randString),
 				Check: resource.ComposeTestCheckFunc(

--- a/jenkins/provider.go
+++ b/jenkins/provider.go
@@ -9,7 +9,10 @@ import (
 )
 
 const (
-	defaultValueDomain = "_"
+	// defaultCredentialDomain is the default domain that all credentials go into.
+	//
+	// The value represents "All domains" in the Jenkins system.
+	defaultCredentialDomain = "_"
 )
 
 // Provider creates a new Jenkins provider.

--- a/jenkins/resource.go
+++ b/jenkins/resource.go
@@ -1,0 +1,101 @@
+package jenkins
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+type (
+	// resourceHelper provides assistive snippets of logic to help reduce duplication in
+	// each resource definition.
+	resourceHelper struct {
+		client *jenkinsAdapter
+	}
+)
+
+func newResourceHelper() *resourceHelper {
+	return &resourceHelper{}
+}
+
+// Configure should register the client for the resource.
+func (r *resourceHelper) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*jenkinsAdapter)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *jenkinsAdapter, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client = client
+}
+
+func (r *resourceHelper) schema(s map[string]schema.Attribute) map[string]schema.Attribute {
+	s["id"] = schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: "The full canonical job path, e.g. `/job/job-name`",
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
+		},
+	}
+	s["name"] = schema.StringAttribute{
+		Required:            true,
+		MarkdownDescription: "The name of the credentials being created. This maps to the ID property within Jenkins, and cannot be changed once set.",
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.RequiresReplace(),
+		},
+	}
+	s["folder"] = schema.StringAttribute{
+		MarkdownDescription: "The folder namespace to store the credentials in. If not set will default to global Jenkins credentials.",
+		Optional:            true,
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.RequiresReplace(),
+		},
+	}
+	s["description"] = schema.StringAttribute{
+		MarkdownDescription: "A human readable description of the credentials being stored.",
+		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString("Managed by Terraform"),
+	}
+
+	return s
+}
+func (r *resourceHelper) schemaCredential(s map[string]schema.Attribute) map[string]schema.Attribute {
+	s = r.schema(s)
+	s["domain"] = schema.StringAttribute{
+		MarkdownDescription: "The domain store to place the credentials into. If not set will default to the global credentials store.",
+		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(defaultCredentialDomain),
+		PlanModifiers: []planmodifier.String{
+			// In-place updates should be possible, but gojenkins does not support move operations
+			stringplanmodifier.RequiresReplace(),
+		},
+	}
+	s["scope"] = schema.StringAttribute{
+		MarkdownDescription: `The visibility of the credentials to Jenkins agents. This must be set to either "GLOBAL" or "SYSTEM". If not set will default to "GLOBAL".`,
+		Computed:            true,
+		Default:             stringdefault.StaticString("GLOBAL"),
+		Validators: []validator.String{
+			stringvalidator.OneOf(supportedCredentialScopes...),
+		},
+	}
+
+	return s
+}

--- a/jenkins/resource_jenkins_credential_azure_service_principal.go
+++ b/jenkins/resource_jenkins_credential_azure_service_principal.go
@@ -53,7 +53,7 @@ func resourceJenkinsCredentialAzureServicePrincipal() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The Jenkins domain that the credentials will be added to.",
 				Optional:    true,
-				Default:     "_",
+				Default:     defaultCredentialDomain,
 				// In-place updates should be possible, but gojenkins does not support move operations
 				ForceNew: true,
 			},

--- a/jenkins/resource_jenkins_credential_secret_file.go
+++ b/jenkins/resource_jenkins_credential_secret_file.go
@@ -30,7 +30,7 @@ func resourceJenkinsCredentialSecretFile() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The domain namespace that the credentials will be added to.",
 				Optional:    true,
-				Default:     "_",
+				Default:     defaultCredentialDomain,
 				// In-place updates should be possible, but gojenkins does not support move operations
 				ForceNew: true,
 			},

--- a/jenkins/resource_jenkins_credential_secret_text.go
+++ b/jenkins/resource_jenkins_credential_secret_text.go
@@ -30,7 +30,7 @@ func resourceJenkinsCredentialSecretText() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The domain namespace that the credentials will be added to.",
 				Optional:    true,
-				Default:     "_",
+				Default:     defaultCredentialDomain,
 				// In-place updates should be possible, but gojenkins does not support move operations
 				ForceNew: true,
 			},

--- a/jenkins/resource_jenkins_credential_ssh.go
+++ b/jenkins/resource_jenkins_credential_ssh.go
@@ -30,7 +30,7 @@ func resourceJenkinsCredentialSSH() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The domain namespace that the credentials will be added to.",
 				Optional:    true,
-				Default:     "_",
+				Default:     defaultCredentialDomain,
 				// In-place updates should be possible, but gojenkins does not support move operations
 				ForceNew: true,
 			},

--- a/jenkins/resource_jenkins_credential_username.go
+++ b/jenkins/resource_jenkins_credential_username.go
@@ -6,61 +6,39 @@ import (
 	"strings"
 
 	jenkins "github.com/bndr/gojenkins"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type credentialUsernameResourceModel struct {
 	ID          types.String `tfsdk:"id"`
 	Name        types.String `tfsdk:"name"`
-	Domain      types.String `tfsdk:"domain"`
 	Folder      types.String `tfsdk:"folder"`
-	Scope       types.String `tfsdk:"scope"`
 	Description types.String `tfsdk:"description"`
+	Domain      types.String `tfsdk:"domain"`
+	Scope       types.String `tfsdk:"scope"`
 	Username    types.String `tfsdk:"username"`
 	Password    types.String `tfsdk:"password"`
 }
 
 type credentialUsernameResource struct {
-	client *jenkinsAdapter
+	*resourceHelper
 }
 
+// Ensure the implementation satisfies the desired interfaces.
 var _ resource.ResourceWithConfigure = &credentialUsernameResource{}
 
 func newCredentialUsernameResource() resource.Resource {
-	return &credentialUsernameResource{}
+	return &credentialUsernameResource{
+		resourceHelper: newResourceHelper(),
+	}
 }
 
 // Metadata should return the full name of the resource.
 func (r *credentialUsernameResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_credential_username"
-}
-
-// Configure should register the client for the resource.
-func (r *credentialUsernameResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	// Prevent panic if the provider has not been configured.
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*jenkinsAdapter)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *jenkinsAdapter, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	r.client = client
 }
 
 // Schema should return the schema for this resource.
@@ -70,52 +48,7 @@ func (r *credentialUsernameResource) Schema(_ context.Context, _ resource.Schema
 Manages a username credential within Jenkins. This username may then be referenced within jobs that are created.
 
 ~> The "password" property may leave plain-text passwords in your state file. If using the property to manage the password in Terraform, ensure that your state file is properly secured and encrypted at rest.`,
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "The full canonical job path, e.g. `/job/job-name`",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"name": schema.StringAttribute{
-				Required:            true,
-				MarkdownDescription: "The name of the credentials being created. This maps to the ID property within Jenkins, and cannot be changed once set.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
-			"domain": schema.StringAttribute{
-				MarkdownDescription: "The domain store to place the credentials into. If not set will default to the global credentials store.",
-				Optional:            true,
-				Computed:            true,
-				Default:             stringdefault.StaticString(defaultCredentialDomain),
-				PlanModifiers: []planmodifier.String{
-					// In-place updates should be possible, but gojenkins does not support move operations
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
-			"folder": schema.StringAttribute{
-				MarkdownDescription: "The folder namespace to store the credentials in. If not set will default to global Jenkins credentials.",
-				Optional:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
-			"scope": schema.StringAttribute{
-				MarkdownDescription: `The visibility of the credentials to Jenkins agents. This must be set to either "GLOBAL" or "SYSTEM". If not set will default to "GLOBAL".`,
-				Computed:            true,
-				Default:             stringdefault.StaticString("GLOBAL"),
-				Validators: []validator.String{
-					stringvalidator.OneOf(supportedCredentialScopes...),
-				},
-			},
-			"description": schema.StringAttribute{
-				MarkdownDescription: "A human readable description of the credentials being stored.",
-				Optional:            true,
-				Computed:            true,
-				Default:             stringdefault.StaticString("Managed by Terraform"),
-			},
+		Attributes: r.schemaCredential(map[string]schema.Attribute{
 			"username": schema.StringAttribute{
 				MarkdownDescription: "The username to be associated with the credentials.",
 				Required:            true,
@@ -125,7 +58,7 @@ Manages a username credential within Jenkins. This username may then be referenc
 				Optional:            true,
 				Sensitive:           true,
 			},
-		},
+		}),
 	}
 }
 

--- a/jenkins/resource_jenkins_credential_username.go
+++ b/jenkins/resource_jenkins_credential_username.go
@@ -89,7 +89,7 @@ Manages a username credential within Jenkins. This username may then be referenc
 				MarkdownDescription: "The domain store to place the credentials into. If not set will default to the global credentials store.",
 				Optional:            true,
 				Computed:            true,
-				Default:             stringdefault.StaticString("_"),
+				Default:             stringdefault.StaticString(defaultCredentialDomain),
 				PlanModifiers: []planmodifier.String{
 					// In-place updates should be possible, but gojenkins does not support move operations
 					stringplanmodifier.RequiresReplace(),

--- a/jenkins/resource_jenkins_credential_vault_approle.go
+++ b/jenkins/resource_jenkins_credential_vault_approle.go
@@ -105,7 +105,7 @@ Manages a Vault AppRole credential within Jenkins. This credential may then be r
 				MarkdownDescription: "The domain store to place the credentials into. If not set will default to the global credentials store.",
 				Optional:            true,
 				Computed:            true,
-				Default:             stringdefault.StaticString(defaultValueDomain),
+				Default:             stringdefault.StaticString(defaultCredentialDomain),
 				PlanModifiers: []planmodifier.String{
 					// In-place updates should be possible, but gojenkins does not support move operations
 					stringplanmodifier.RequiresReplace(),

--- a/jenkins/resource_jenkins_credential_vault_approle.go
+++ b/jenkins/resource_jenkins_credential_vault_approle.go
@@ -6,14 +6,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -32,10 +28,10 @@ type VaultAppRoleCredentials struct {
 type credentialVaultAppRoleResourceModel struct {
 	ID          types.String `tfsdk:"id"`
 	Name        types.String `tfsdk:"name"`
-	Domain      types.String `tfsdk:"domain"`
 	Folder      types.String `tfsdk:"folder"`
-	Scope       types.String `tfsdk:"scope"`
 	Description types.String `tfsdk:"description"`
+	Domain      types.String `tfsdk:"domain"`
+	Scope       types.String `tfsdk:"scope"`
 	Namespace   types.String `tfsdk:"namespace"`
 	Path        types.String `tfsdk:"path"`
 	RoleID      types.String `tfsdk:"role_id"`
@@ -43,38 +39,21 @@ type credentialVaultAppRoleResourceModel struct {
 }
 
 type credentialVaultAppRoleResource struct {
-	client *jenkinsAdapter
+	*resourceHelper
 }
 
+// Ensure the implementation satisfies the desired interfaces.
 var _ resource.ResourceWithConfigure = &credentialVaultAppRoleResource{}
 
 func newCredentialVaultAppRoleResource() resource.Resource {
-	return &credentialVaultAppRoleResource{}
+	return &credentialVaultAppRoleResource{
+		resourceHelper: newResourceHelper(),
+	}
 }
 
 // Metadata should return the full name of the resource.
 func (r *credentialVaultAppRoleResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_credential_vault_approle"
-}
-
-// Configure should register the client for the resource.
-func (r *credentialVaultAppRoleResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	// Prevent panic if the provider has not been configured.
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*jenkinsAdapter)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *jenkinsAdapter, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	r.client = client
 }
 
 // Schema should return the schema for this resource.
@@ -86,52 +65,7 @@ Manages a Vault AppRole credential within Jenkins. This credential may then be r
 ~> The "secret_id" property may leave plain-text secret id in your state file. If using the property to manage the secret id in Terraform, ensure that your state file is properly secured and encrypted at rest.
 
 ~> The Jenkins installation that uses this resource is expected to have the [Hashicorp Vault Plugin](https://plugins.jenkins.io/hashicorp-vault-plugin/) installed in their system.`,
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "The full canonical job path, e.g. `/job/job-name`",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"name": schema.StringAttribute{
-				Required:            true,
-				MarkdownDescription: "The name of the credentials being created. This maps to the ID property within Jenkins, and cannot be changed once set.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
-			"domain": schema.StringAttribute{
-				MarkdownDescription: "The domain store to place the credentials into. If not set will default to the global credentials store.",
-				Optional:            true,
-				Computed:            true,
-				Default:             stringdefault.StaticString(defaultCredentialDomain),
-				PlanModifiers: []planmodifier.String{
-					// In-place updates should be possible, but gojenkins does not support move operations
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
-			"folder": schema.StringAttribute{
-				MarkdownDescription: "The folder namespace to store the credentials in. If not set will default to global Jenkins credentials.",
-				Optional:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
-			"scope": schema.StringAttribute{
-				MarkdownDescription: `The visibility of the credentials to Jenkins agents. This must be set to either "GLOBAL" or "SYSTEM". If not set will default to "GLOBAL".`,
-				Computed:            true,
-				Default:             stringdefault.StaticString("GLOBAL"),
-				Validators: []validator.String{
-					stringvalidator.OneOf(supportedCredentialScopes...),
-				},
-			},
-			"description": schema.StringAttribute{
-				MarkdownDescription: "A human readable description of the credentials being stored.",
-				Optional:            true,
-				Computed:            true,
-				Default:             stringdefault.StaticString("Managed by Terraform"),
-			},
+		Attributes: r.schemaCredential(map[string]schema.Attribute{
 			"namespace": schema.StringAttribute{
 				MarkdownDescription: "The Vault namespace of the approle credential.",
 				Optional:            true,
@@ -153,7 +87,7 @@ Manages a Vault AppRole credential within Jenkins. This credential may then be r
 				Optional:            true,
 				Sensitive:           true,
 			},
-		},
+		}),
 	}
 }
 


### PR DESCRIPTION
# What Is Changing

Reducing code duplication in the migrated Framework resources & data sources by configuring helpers for each that absorb common function definitions and attributes.

# Test Steps

- [x] If you've changed documentation, have you run `make generate` to render the `docs/` folder?
- [x] Have you updated the `integration/` tests with a [terraform test](https://developer.hashicorp.com/terraform/language/tests) compatible change?
