### PR TITLE
Reduce duplication in Import block

### DIFF
--- a/jenkins/resource_jenkins_credential_azure_service_principal.go
+++ b/jenkins/resource_jenkins_credential_azure_service_principal.go
@@ -346,26 +346,3 @@ func (r *credentialAzureServicePrincipalResource) Delete(ctx context.Context, re
 		return
 	}
 }
-
-// ImportState is called when performing import operations of existing resources.
-func (r *credentialAzureServicePrincipalResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	splitID := strings.Split(req.ID, "/")
-	if len(splitID) < 2 {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: \"[<folder>/]<domain>/<name>\". Got: %q", req.ID),
-		)
-		return
-	}
-
-	name := splitID[len(splitID)-1]
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), name)...)
-
-	domain := splitID[len(splitID)-2]
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain"), domain)...)
-
-	folder := strings.Trim(strings.Join(splitID[0:len(splitID)-2], "/"), "/")
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("folder"), folder)...)
-
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), generateCredentialID(folder, name))...)
-}

--- a/jenkins/resource_jenkins_credential_secret_file.go
+++ b/jenkins/resource_jenkins_credential_secret_file.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	jenkins "github.com/bndr/gojenkins"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -230,27 +229,4 @@ func (r *credentialSecretFileResource) Delete(ctx context.Context, req resource.
 
 		return
 	}
-}
-
-// ImportState is called when performing import operations of existing resources.
-func (r *credentialSecretFileResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	splitID := strings.Split(req.ID, "/")
-	if len(splitID) < 2 {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: \"[<folder>/]<domain>/<name>\". Got: %q", req.ID),
-		)
-		return
-	}
-
-	name := splitID[len(splitID)-1]
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), name)...)
-
-	domain := splitID[len(splitID)-2]
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain"), domain)...)
-
-	folder := strings.Trim(strings.Join(splitID[0:len(splitID)-2], "/"), "/")
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("folder"), folder)...)
-
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), generateCredentialID(folder, name))...)
 }

--- a/jenkins/resource_jenkins_credential_username.go
+++ b/jenkins/resource_jenkins_credential_username.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	jenkins "github.com/bndr/gojenkins"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -231,27 +230,4 @@ func (r *credentialUsernameResource) Delete(ctx context.Context, req resource.De
 
 		return
 	}
-}
-
-// ImportState is called when performing import operations of existing resources.
-func (r *credentialUsernameResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	splitID := strings.Split(req.ID, "/")
-	if len(splitID) < 2 {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: \"[<folder>/]<domain>/<name>\". Got: %q", req.ID),
-		)
-		return
-	}
-
-	name := splitID[len(splitID)-1]
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), name)...)
-
-	domain := splitID[len(splitID)-2]
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain"), domain)...)
-
-	folder := strings.Trim(strings.Join(splitID[0:len(splitID)-2], "/"), "/")
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("folder"), folder)...)
-
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), generateCredentialID(folder, name))...)
 }

--- a/jenkins/resource_jenkins_credential_vault_approle.go
+++ b/jenkins/resource_jenkins_credential_vault_approle.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -266,27 +265,4 @@ func (r *credentialVaultAppRoleResource) Delete(ctx context.Context, req resourc
 
 		return
 	}
-}
-
-// ImportState is called when performing import operations of existing resources.
-func (r *credentialVaultAppRoleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	splitID := strings.Split(req.ID, "/")
-	if len(splitID) < 2 {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: \"[<folder>/]<domain>/<name>\". Got: %q", req.ID),
-		)
-		return
-	}
-
-	name := splitID[len(splitID)-1]
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), name)...)
-
-	domain := splitID[len(splitID)-2]
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain"), domain)...)
-
-	folder := strings.Trim(strings.Join(splitID[0:len(splitID)-2], "/"), "/")
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("folder"), folder)...)
-
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), generateCredentialID(folder, name))...)
 }


### PR DESCRIPTION
# What Is Changing

Rolling up the Import block into the `resource` helper, to reduce duplication.

# Test Steps

- [x] If you've changed documentation, have you run `make generate` to render the `docs/` folder?
- [x] Have you updated the `integration/` tests with a [terraform test](https://developer.hashicorp.com/terraform/language/tests) compatible change?

<!-- Additional test steps go here. -->
