### PR TITLE
Migrate View Resource & Data Source to Framework

### DIFF
--- a/docs/data-sources/view.md
+++ b/docs/data-sources/view.md
@@ -3,12 +3,12 @@
 page_title: "jenkins_view Data Source - terraform-provider-jenkins"
 subcategory: ""
 description: |-
-  
+  Get the attributes of a view within Jenkins.
 ---
 
 # jenkins_view (Data Source)
 
-
+Get the attributes of a view within Jenkins.
 
 
 
@@ -17,14 +17,14 @@ description: |-
 
 ### Required
 
-- `name` (String) The unique name of the Jenkins view.
+- `name` (String) The name of the resource being read.
 
 ### Optional
 
-- `folder` (String) The folder namespace that the job exists in.
+- `folder` (String) The folder namespace containing this resource.
 
 ### Read-Only
 
-- `description` (String) The description for the view.
-- `id` (String) The ID of this resource.
+- `description` (String) A human readable description of the resource.
+- `id` (String) The unique name of this view.
 - `url` (String) The url for the view.

--- a/docs/resources/credential_azure_service_principal.md
+++ b/docs/resources/credential_azure_service_principal.md
@@ -34,7 +34,7 @@ resource "jenkins_credential_azure_service_principal" "foo" {
 ### Required
 
 - `client_id` (String) The client id (application id) of the Azure Service Principal.
-- `name` (String) The name of the credentials being created. This maps to the ID property within Jenkins, and cannot be changed once set.
+- `name` (String) The name of the resource being created. This maps to the ID property within Jenkins, and cannot be changed once set.
 - `subscription_id` (String) The Azure subscription id mapped to the Azure Service Principal.
 - `tenant` (String) The Azure Tenant ID of the Azure Service Principal.
 
@@ -46,7 +46,7 @@ resource "jenkins_credential_azure_service_principal" "foo" {
 - `client_secret` (String, Sensitive) The client secret of the Azure Service Principal. Cannot be used with `certificate_id`. Has to be specified, if `certificate_id` is not specified.
 - `description` (String) A human readable description of the credentials being stored.
 - `domain` (String) The domain store to place the credentials into. If not set will default to the global credentials store.
-- `folder` (String) The folder namespace to store the credentials in. If not set will default to global Jenkins credentials.
+- `folder` (String) The folder namespace to store the resource in. If not set will default to global Jenkins.
 - `graph_endpoint` (String) Override the Azure graph endpoint URL for the selected Azure environment.
 - `resource_manager_endpoint` (String) Override the Azure resource manager endpoint URL for the selected Azure environment.
 - `scope` (String) The visibility of the credentials to Jenkins agents. This must be set to either "GLOBAL" or "SYSTEM". If not set will default to "GLOBAL".

--- a/docs/resources/credential_secret_file.md
+++ b/docs/resources/credential_secret_file.md
@@ -26,14 +26,14 @@ resource "jenkins_credential_secret_file" "example" {
 ### Required
 
 - `filename` (String) The secret file filename on jenkins server side.
-- `name` (String) The name of the credentials being created. This maps to the ID property within Jenkins, and cannot be changed once set.
+- `name` (String) The name of the resource being created. This maps to the ID property within Jenkins, and cannot be changed once set.
 - `secretbytes` (String, Sensitive) The secret file, base64 encoded content. It can be sourced directly from local file with filebase64(path) TF function or given directly.
 
 ### Optional
 
 - `description` (String) A human readable description of the credentials being stored.
 - `domain` (String) The domain store to place the credentials into. If not set will default to the global credentials store.
-- `folder` (String) The folder namespace to store the credentials in. If not set will default to global Jenkins credentials.
+- `folder` (String) The folder namespace to store the resource in. If not set will default to global Jenkins.
 - `scope` (String) The visibility of the credentials to Jenkins agents. This must be set to either "GLOBAL" or "SYSTEM". If not set will default to "GLOBAL".
 
 ### Read-Only

--- a/docs/resources/credential_secret_text.md
+++ b/docs/resources/credential_secret_text.md
@@ -24,14 +24,14 @@ resource "jenkins_credential_secret_text" "example" {
 
 ### Required
 
-- `name` (String) The name of the credentials being created. This maps to the ID property within Jenkins, and cannot be changed once set.
+- `name` (String) The name of the resource being created. This maps to the ID property within Jenkins, and cannot be changed once set.
 - `secret` (String, Sensitive) The secret text to be associated with the credentials.
 
 ### Optional
 
 - `description` (String) A human readable description of the credentials being stored.
 - `domain` (String) The domain store to place the credentials into. If not set will default to the global credentials store.
-- `folder` (String) The folder namespace to store the credentials in. If not set will default to global Jenkins credentials.
+- `folder` (String) The folder namespace to store the resource in. If not set will default to global Jenkins.
 - `scope` (String) The visibility of the credentials to Jenkins agents. This must be set to either "GLOBAL" or "SYSTEM". If not set will default to "GLOBAL".
 
 ### Read-Only

--- a/docs/resources/credential_ssh.md
+++ b/docs/resources/credential_ssh.md
@@ -29,7 +29,7 @@ resource "jenkins_credential_ssh" "example" {
 
 ### Required
 
-- `name` (String) The name of the credentials being created. This maps to the ID property within Jenkins, and cannot be changed once set.
+- `name` (String) The name of the resource being created. This maps to the ID property within Jenkins, and cannot be changed once set.
 - `privatekey` (String, Sensitive) Private SSH key, can be given as string or read from file with 'file()' terraform function.
 - `username` (String) Username
 
@@ -37,7 +37,7 @@ resource "jenkins_credential_ssh" "example" {
 
 - `description` (String) A human readable description of the credentials being stored.
 - `domain` (String) The domain store to place the credentials into. If not set will default to the global credentials store.
-- `folder` (String) The folder namespace to store the credentials in. If not set will default to global Jenkins credentials.
+- `folder` (String) The folder namespace to store the resource in. If not set will default to global Jenkins.
 - `passphrase` (String, Sensitive) Passphrase for privatekey. This has to be skipped if private key was created without passphrase.
 - `scope` (String) The visibility of the credentials to Jenkins agents. This must be set to either "GLOBAL" or "SYSTEM". If not set will default to "GLOBAL".
 

--- a/docs/resources/credential_username.md
+++ b/docs/resources/credential_username.md
@@ -29,14 +29,14 @@ resource "jenkins_credential_username" "example" {
 
 ### Required
 
-- `name` (String) The name of the credentials being created. This maps to the ID property within Jenkins, and cannot be changed once set.
+- `name` (String) The name of the resource being created. This maps to the ID property within Jenkins, and cannot be changed once set.
 - `username` (String) The username to be associated with the credentials.
 
 ### Optional
 
 - `description` (String) A human readable description of the credentials being stored.
 - `domain` (String) The domain store to place the credentials into. If not set will default to the global credentials store.
-- `folder` (String) The folder namespace to store the credentials in. If not set will default to global Jenkins credentials.
+- `folder` (String) The folder namespace to store the resource in. If not set will default to global Jenkins.
 - `password` (String, Sensitive) The password to be associated with the credentials. If empty then the password property will become unmanaged and expected to be set manually within Jenkins. If set then the password will be updated only upon changes -- if the password is set manually within Jenkins then it will not reconcile this drift until the next time the password property is changed.
 - `scope` (String) The visibility of the credentials to Jenkins agents. This must be set to either "GLOBAL" or "SYSTEM". If not set will default to "GLOBAL".
 

--- a/docs/resources/credential_vault_approle.md
+++ b/docs/resources/credential_vault_approle.md
@@ -31,14 +31,14 @@ resource "jenkins_credential_vault_approle" "example" {
 
 ### Required
 
-- `name` (String) The name of the credentials being created. This maps to the ID property within Jenkins, and cannot be changed once set.
+- `name` (String) The name of the resource being created. This maps to the ID property within Jenkins, and cannot be changed once set.
 - `role_id` (String) The role_id to be associated with the credentials.
 
 ### Optional
 
 - `description` (String) A human readable description of the credentials being stored.
 - `domain` (String) The domain store to place the credentials into. If not set will default to the global credentials store.
-- `folder` (String) The folder namespace to store the credentials in. If not set will default to global Jenkins credentials.
+- `folder` (String) The folder namespace to store the resource in. If not set will default to global Jenkins.
 - `namespace` (String) The Vault namespace of the approle credential.
 - `path` (String) The unique name of the approle auth backend. Defaults to `approle`.
 - `scope` (String) The visibility of the credentials to Jenkins agents. This must be set to either "GLOBAL" or "SYSTEM". If not set will default to "GLOBAL".

--- a/docs/resources/view.md
+++ b/docs/resources/view.md
@@ -3,12 +3,15 @@
 page_title: "jenkins_view Resource - terraform-provider-jenkins"
 subcategory: ""
 description: |-
-  
+  Manages a view within Jenkins.
+  ~> Due to API client limitations, updates to some attributes may be restricted.
 ---
 
 # jenkins_view (Resource)
 
+Manages a view within Jenkins.
 
+~> Due to API client limitations, updates to some attributes may be restricted.
 
 
 
@@ -17,15 +20,15 @@ description: |-
 
 ### Required
 
-- `name` (String)
+- `name` (String) The name of the resource being created. This maps to the ID property within Jenkins, and cannot be changed once set.
 
 ### Optional
 
-- `assigned_projects` (List of String)
-- `folder` (String) The folder namespace that the job exists in.
+- `assigned_projects` (List of String) The list of projects assigned to the view.
+- `folder` (String) The folder namespace to store the resource in. If not set will default to global Jenkins.
 
 ### Read-Only
 
 - `description` (String) The description for the view.
-- `id` (String) The ID of this resource.
+- `id` (String) The unique name of this view.
 - `url` (String) The url for the view.

--- a/docs/resources/view.md
+++ b/docs/resources/view.md
@@ -24,7 +24,7 @@ Manages a view within Jenkins.
 
 ### Optional
 
-- `assigned_projects` (List of String) The list of projects assigned to the view.
+- `assigned_projects` (List of String) The list of projects assigned to the view. For example, the name of a folder.
 - `folder` (String) The folder namespace to store the resource in. If not set will default to global Jenkins.
 
 ### Read-Only

--- a/integration/jobs/view.tf
+++ b/integration/jobs/view.tf
@@ -1,0 +1,14 @@
+resource "jenkins_view" "example" {
+  name   = "example"
+  folder = jenkins_folder.example.id
+}
+
+data "jenkins_view" "example" {
+  depends_on = [jenkins_view.example]
+  name       = "example"
+  folder     = jenkins_folder.example.id
+}
+
+output "view" {
+  value = data.jenkins_view.example
+}

--- a/integration/jobs/view.tf
+++ b/integration/jobs/view.tf
@@ -1,12 +1,13 @@
 resource "jenkins_view" "example" {
-  name   = "example"
-  folder = jenkins_folder.example.id
+  name = "example"
+  assigned_projects = [
+    jenkins_folder.example.name,
+  ]
 }
 
 data "jenkins_view" "example" {
   depends_on = [jenkins_view.example]
   name       = "example"
-  folder     = jenkins_folder.example.id
 }
 
 output "view" {

--- a/integration/main.tftest.hcl
+++ b/integration/main.tftest.hcl
@@ -29,15 +29,17 @@ run "jobs" {
     condition     = chomp(coalesce(data.jenkins_job.pipeline_scm.template, "")) == chomp(local.pipeline_scm_template)
     error_message = "${data.jenkins_job.pipeline_scm.name} produced inconsistent XML"
   }
-
   assert {
     condition     = chomp(data.jenkins_job.pipeline_inline.template) == chomp(local.pipeline_inline_template)
     error_message = "${data.jenkins_job.pipeline_inline.name} produced inconsistent XML"
   }
-
   assert {
     condition     = chomp(data.jenkins_job.freestyle.template) == chomp(local.freestyle_template)
     error_message = "${data.jenkins_job.freestyle.name} produced inconsistent XML"
+  }
+  assert {
+    condition     = output.view.name == "example"
+    error_message = "${output.view.name} did not contain expected \"example\" value"
   }
 }
 

--- a/jenkins/data_source.go
+++ b/jenkins/data_source.go
@@ -41,35 +41,58 @@ func (d *dataSourceHelper) Configure(ctx context.Context, req datasource.Configu
 }
 
 func (d *dataSourceHelper) schema(s map[string]schema.Attribute) map[string]schema.Attribute {
-	s["id"] = schema.StringAttribute{
-		Computed:            true,
-		MarkdownDescription: "The full canonical job path, e.g. `/job/job-name`",
+	if _, ok := s["id"]; !ok {
+		s["id"] = schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "The full canonical job path, e.g. `/job/job-name`",
+		}
 	}
-	s["name"] = schema.StringAttribute{
-		Required:            true,
-		MarkdownDescription: "The name of the resource being read.",
+	if _, ok := s["name"]; !ok {
+		s["name"] = schema.StringAttribute{
+			Required:            true,
+			MarkdownDescription: "The name of the resource being read.",
+		}
 	}
-	s["folder"] = schema.StringAttribute{
-		MarkdownDescription: "The folder namespace containing this resource.",
-		Optional:            true,
+	if _, ok := s["folder"]; !ok {
+		s["folder"] = schema.StringAttribute{
+			MarkdownDescription: "The folder namespace containing this resource.",
+			Optional:            true,
+		}
 	}
-	s["description"] = schema.StringAttribute{
-		MarkdownDescription: "A human readable description of the credentials being stored.",
-		Computed:            true,
+	if _, ok := s["description"]; !ok {
+		s["description"] = schema.StringAttribute{
+			MarkdownDescription: "A human readable description of the resource.",
+			Computed:            true,
+		}
 	}
 
 	return s
 }
 
 func (d *dataSourceHelper) schemaCredential(s map[string]schema.Attribute) map[string]schema.Attribute {
-	s = d.schema(s)
-	s["domain"] = schema.StringAttribute{
-		MarkdownDescription: "The domain store containing this resource.",
-		Optional:            true,
+	// Override the base schema with more specific messaging
+	if _, ok := s["description"]; !ok {
+		s["description"] = schema.StringAttribute{
+			MarkdownDescription: "A human readable description of the credentials being stored.",
+			Computed:            true,
+		}
 	}
-	s["scope"] = schema.StringAttribute{
-		MarkdownDescription: `The visibility of the credentials to Jenkins agents. This will be either "GLOBAL" or "SYSTEM".`,
-		Computed:            true,
+
+	// Pull in the base schema
+	s = d.schema(s)
+
+	// Add credential-specific attributes
+	if _, ok := s["domain"]; !ok {
+		s["domain"] = schema.StringAttribute{
+			MarkdownDescription: "The domain store containing this resource.",
+			Optional:            true,
+		}
+	}
+	if _, ok := s["scope"]; !ok {
+		s["scope"] = schema.StringAttribute{
+			MarkdownDescription: `The visibility of the credentials to Jenkins agents. This will be either "GLOBAL" or "SYSTEM".`,
+			Computed:            true,
+		}
 	}
 
 	return s

--- a/jenkins/data_source_jenkins_view.go
+++ b/jenkins/data_source_jenkins_view.go
@@ -3,43 +3,78 @@ package jenkins
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func dataSourceJenkinsView() *schema.Resource {
-	return &schema.Resource{
-		ReadContext: dataSourceJenkinsViewRead,
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:        schema.TypeString,
-				Description: "The unique name of the Jenkins view.",
-				Required:    true,
-			},
-			"folder": {
-				Type:             schema.TypeString,
-				Description:      "The folder namespace that the job exists in.",
-				Optional:         true,
-				ValidateDiagFunc: validateFolderName,
-			},
-			"description": {
-				Type:        schema.TypeString,
-				Description: "The description for the view.",
-				Computed:    true,
-			},
-			"url": {
-				Type:        schema.TypeString,
-				Description: "The url for the view.",
-				Computed:    true,
-			},
-		},
+type ViewDataSourceModel struct {
+	ID          types.String `tfsdk:"id"`
+	Name        types.String `tfsdk:"name"`
+	Folder      types.String `tfsdk:"folder"`
+	Description types.String `tfsdk:"description"`
+	URL         types.String `tfsdk:"url"`
+}
+
+type ViewDataSource struct {
+	*dataSourceHelper
+}
+
+// Ensure the implementation satisfies the desired interfaces.
+var _ datasource.DataSourceWithConfigure = &ViewDataSource{}
+
+func newViewDataSource() datasource.DataSource {
+	return &ViewDataSource{
+		dataSourceHelper: newDataSourceHelper(),
 	}
 }
 
-func dataSourceJenkinsViewRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	name := d.Get("name").(string)
-	folderName := d.Get("folder").(string)
-	d.SetId(formatFolderName(folderName + "/" + name))
+func (d *ViewDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_view"
+}
 
-	return resourceJenkinsViewRead(ctx, d, meta)
+func (d *ViewDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Get the attributes of a view within Jenkins.",
+		Attributes: d.schema(map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The unique name of this view.",
+			},
+			"url": schema.StringAttribute{
+				MarkdownDescription: "The url for the view.",
+				Computed:            true,
+			},
+		}),
+	}
+}
+
+func (d *ViewDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data ViewDataSourceModel
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	view, err := d.client.GetView(ctx, data.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Data Source",
+			"An unexpected error occurred while parsing the data source read response. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	data.ID = types.StringValue(view.GetName())
+	data.Name = types.StringValue(view.GetName())
+	data.Description = types.StringValue(view.GetDescription())
+	data.URL = types.StringValue(view.GetUrl())
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/jenkins/provider.go
+++ b/jenkins/provider.go
@@ -51,7 +51,6 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"jenkins_folder": resourceJenkinsFolder(),
 			"jenkins_job":    resourceJenkinsJob(),
-			"jenkins_view":   resourceJenkinsView(),
 		},
 
 		ConfigureContextFunc: configureProvider,

--- a/jenkins/provider.go
+++ b/jenkins/provider.go
@@ -46,7 +46,6 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"jenkins_folder": dataSourceJenkinsFolder(),
 			"jenkins_job":    dataSourceJenkinsJob(),
-			"jenkins_view":   dataSourceJenkinsView(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/jenkins/provider_framework.go
+++ b/jenkins/provider_framework.go
@@ -137,5 +137,6 @@ func (p *JenkinsProvider) Resources(ctx context.Context) []func() resource.Resou
 		newCredentialSSHResource,
 		newCredentialUsernameResource,
 		newCredentialVaultAppRoleResource,
+		newViewResource,
 	}
 }

--- a/jenkins/provider_framework.go
+++ b/jenkins/provider_framework.go
@@ -124,6 +124,7 @@ func (p *JenkinsProvider) DataSources(ctx context.Context) []func() datasource.D
 	return []func() datasource.DataSource{
 		newCredentialUsernameDataSource,
 		newCredentialVaultAppRoleDataSource,
+		newViewDataSource,
 	}
 }
 

--- a/jenkins/resource.go
+++ b/jenkins/resource.go
@@ -71,56 +71,81 @@ func (r *resourceHelper) ImportState(ctx context.Context, req resource.ImportSta
 }
 
 func (r *resourceHelper) schema(s map[string]schema.Attribute) map[string]schema.Attribute {
-	s["id"] = schema.StringAttribute{
-		Computed:            true,
-		MarkdownDescription: "The full canonical job path, e.g. `/job/job-name`",
-		PlanModifiers: []planmodifier.String{
-			stringplanmodifier.UseStateForUnknown(),
-		},
+	if _, ok := s["id"]; !ok {
+		s["id"] = schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "The full canonical job path, e.g. `/job/job-name`",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		}
 	}
-	s["name"] = schema.StringAttribute{
-		Required:            true,
-		MarkdownDescription: "The name of the credentials being created. This maps to the ID property within Jenkins, and cannot be changed once set.",
-		PlanModifiers: []planmodifier.String{
-			stringplanmodifier.RequiresReplace(),
-		},
+	if _, ok := s["name"]; !ok {
+		s["name"] = schema.StringAttribute{
+			Required:            true,
+			MarkdownDescription: "The name of the resource being created. This maps to the ID property within Jenkins, and cannot be changed once set.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		}
 	}
-	s["folder"] = schema.StringAttribute{
-		MarkdownDescription: "The folder namespace to store the credentials in. If not set will default to global Jenkins credentials.",
-		Optional:            true,
-		PlanModifiers: []planmodifier.String{
-			stringplanmodifier.RequiresReplace(),
-		},
+	if _, ok := s["folder"]; !ok {
+		s["folder"] = schema.StringAttribute{
+			MarkdownDescription: "The folder namespace to store the resource in. If not set will default to global Jenkins.",
+			Optional:            true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		}
 	}
-	s["description"] = schema.StringAttribute{
-		MarkdownDescription: "A human readable description of the credentials being stored.",
-		Optional:            true,
-		Computed:            true,
-		Default:             stringdefault.StaticString("Managed by Terraform"),
+	if _, ok := s["description"]; !ok {
+		s["description"] = schema.StringAttribute{
+			MarkdownDescription: "A human readable description of the resource.",
+			Optional:            true,
+			Computed:            true,
+			Default:             stringdefault.StaticString("Managed by Terraform"),
+		}
 	}
 
 	return s
 }
 func (r *resourceHelper) schemaCredential(s map[string]schema.Attribute) map[string]schema.Attribute {
-	s = r.schema(s)
-	s["domain"] = schema.StringAttribute{
-		MarkdownDescription: "The domain store to place the credentials into. If not set will default to the global credentials store.",
-		Optional:            true,
-		Computed:            true,
-		Default:             stringdefault.StaticString(defaultCredentialDomain),
-		PlanModifiers: []planmodifier.String{
-			// In-place updates should be possible, but gojenkins does not support move operations
-			stringplanmodifier.RequiresReplace(),
-		},
+	// Override the base schema with more specific messaging
+	if _, ok := s["description"]; !ok {
+		s["description"] = schema.StringAttribute{
+			MarkdownDescription: "A human readable description of the credentials being stored.",
+			Optional:            true,
+			Computed:            true,
+			Default:             stringdefault.StaticString("Managed by Terraform"),
+		}
 	}
-	s["scope"] = schema.StringAttribute{
-		MarkdownDescription: `The visibility of the credentials to Jenkins agents. This must be set to either "GLOBAL" or "SYSTEM". If not set will default to "GLOBAL".`,
-		Optional:            true,
-		Computed:            true,
-		Default:             stringdefault.StaticString("GLOBAL"),
-		Validators: []validator.String{
-			stringvalidator.OneOf(supportedCredentialScopes...),
-		},
+
+	// Pull in the base schema
+	s = r.schema(s)
+
+	// Add credential-specific attributes
+	if _, ok := s["domain"]; !ok {
+		s["domain"] = schema.StringAttribute{
+			MarkdownDescription: "The domain store to place the credentials into. If not set will default to the global credentials store.",
+			Optional:            true,
+			Computed:            true,
+			Default:             stringdefault.StaticString(defaultCredentialDomain),
+			PlanModifiers: []planmodifier.String{
+				// In-place updates should be possible, but gojenkins does not support move operations
+				stringplanmodifier.RequiresReplace(),
+			},
+		}
+	}
+	if _, ok := s["scope"]; !ok {
+		s["scope"] = schema.StringAttribute{
+			MarkdownDescription: `The visibility of the credentials to Jenkins agents. This must be set to either "GLOBAL" or "SYSTEM". If not set will default to "GLOBAL".`,
+			Optional:            true,
+			Computed:            true,
+			Default:             stringdefault.StaticString("GLOBAL"),
+			Validators: []validator.String{
+				stringvalidator.OneOf(supportedCredentialScopes...),
+			},
+		}
 	}
 
 	return s


### PR DESCRIPTION
# What Is Changing

Migrating the `jenkins_view` resource and data source from SDKv2 to the new Plugin Framework.

# Test Steps

- [x] If you've changed documentation, have you run `make generate` to render the `docs/` folder?
- [x] Have you updated the `integration/` tests with a [terraform test](https://developer.hashicorp.com/terraform/language/tests) compatible change?

<!-- Additional test steps go here. -->
