### PR TITLE
Address Failing Integration Test

### DIFF
--- a/integration/jobs/pipeline_inline.xml
+++ b/integration/jobs/pipeline_inline.xml
@@ -16,9 +16,9 @@
     agent any
 
     stages {
-        stage(&apos;Hello&apos;) {
+        stage('Hello') {
             steps {
-                echo &apos;Hello World&apos;
+                echo 'Hello World'
             }
         }
     }


### PR DESCRIPTION
# What Is Changing

Address the failing "job.inline_template" test by unescaping the test XML.

> [!NOTE]
> In the future we will need to properly parse/render the XML or avoid XML entirely. The current version of the job intakes a raw XML string without knowing the difference between the outlying XML and the embedded `<script>` contents.

# Test Steps

- [x] If you've changed documentation, have you run `make generate` to render the `docs/` folder?
- [x] Have you updated the `integration/` tests with a [terraform test](https://developer.hashicorp.com/terraform/language/tests) compatible change?

<!-- Additional test steps go here. -->
