### PR TITLE
Allowing custom descriptions for resources

### DIFF
--- a/docs/data-sources/view.md
+++ b/docs/data-sources/view.md
@@ -25,6 +25,6 @@ Get the attributes of a view within Jenkins.
 
 ### Read-Only
 
-- `description` (String) A human readable description of the resource.
+- `description` (String) A human readable description of the view.
 - `id` (String) The unique name of this view.
 - `url` (String) The url for the view.

--- a/jenkins/data_source.go
+++ b/jenkins/data_source.go
@@ -59,29 +59,21 @@ func (d *dataSourceHelper) schema(s map[string]schema.Attribute) map[string]sche
 			Optional:            true,
 		}
 	}
-	if _, ok := s["description"]; !ok {
-		s["description"] = schema.StringAttribute{
-			MarkdownDescription: "A human readable description of the resource.",
-			Computed:            true,
-		}
-	}
 
 	return s
 }
 
 func (d *dataSourceHelper) schemaCredential(s map[string]schema.Attribute) map[string]schema.Attribute {
-	// Override the base schema with more specific messaging
+	// Pull in the base schema
+	s = d.schema(s)
+
+	// Add credential-specific attributes
 	if _, ok := s["description"]; !ok {
 		s["description"] = schema.StringAttribute{
 			MarkdownDescription: "A human readable description of the credentials being stored.",
 			Computed:            true,
 		}
 	}
-
-	// Pull in the base schema
-	s = d.schema(s)
-
-	// Add credential-specific attributes
 	if _, ok := s["domain"]; !ok {
 		s["domain"] = schema.StringAttribute{
 			MarkdownDescription: "The domain store containing this resource.",

--- a/jenkins/data_source_jenkins_view.go
+++ b/jenkins/data_source_jenkins_view.go
@@ -41,6 +41,10 @@ func (d *ViewDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 				Computed:            true,
 				MarkdownDescription: "The unique name of this view.",
 			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "A human readable description of the view.",
+				Computed:            true,
+			},
 			"url": schema.StringAttribute{
 				MarkdownDescription: "The url for the view.",
 				Computed:            true,

--- a/jenkins/resource.go
+++ b/jenkins/resource.go
@@ -98,19 +98,14 @@ func (r *resourceHelper) schema(s map[string]schema.Attribute) map[string]schema
 			},
 		}
 	}
-	if _, ok := s["description"]; !ok {
-		s["description"] = schema.StringAttribute{
-			MarkdownDescription: "A human readable description of the resource.",
-			Optional:            true,
-			Computed:            true,
-			Default:             stringdefault.StaticString("Managed by Terraform"),
-		}
-	}
 
 	return s
 }
 func (r *resourceHelper) schemaCredential(s map[string]schema.Attribute) map[string]schema.Attribute {
-	// Override the base schema with more specific messaging
+	// Pull in the base schema
+	s = r.schema(s)
+
+	// Add credential-specific attributes
 	if _, ok := s["description"]; !ok {
 		s["description"] = schema.StringAttribute{
 			MarkdownDescription: "A human readable description of the credentials being stored.",
@@ -119,11 +114,6 @@ func (r *resourceHelper) schemaCredential(s map[string]schema.Attribute) map[str
 			Default:             stringdefault.StaticString("Managed by Terraform"),
 		}
 	}
-
-	// Pull in the base schema
-	s = r.schema(s)
-
-	// Add credential-specific attributes
 	if _, ok := s["domain"]; !ok {
 		s["domain"] = schema.StringAttribute{
 			MarkdownDescription: "The domain store to place the credentials into. If not set will default to the global credentials store.",


### PR DESCRIPTION
# What Is Changing

Reducing the opinionated stance of the new Framework implementation around `description` properties. These properties are now able to be custom defined on resources, or omitted entirely.

# Test Steps

- [x] If you've changed documentation, have you run `make generate` to render the `docs/` folder?
- [x] Have you updated the `integration/` tests with a [terraform test](https://developer.hashicorp.com/terraform/language/tests) compatible change?

<!-- Additional test steps go here. -->
