### PR TITLE
Decouple the folder resource from the job resource

### DIFF
--- a/jenkins/resource_jenkins_folder.go
+++ b/jenkins/resource_jenkins_folder.go
@@ -15,7 +15,7 @@ func resourceJenkinsFolder() *schema.Resource {
 		CreateContext: resourceJenkinsFolderCreate,
 		ReadContext:   resourceJenkinsFolderRead,
 		UpdateContext: resourceJenkinsFolderUpdate,
-		DeleteContext: resourceJenkinsJobDelete,
+		DeleteContext: resourceJenkinsFolderDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -207,6 +207,21 @@ func resourceJenkinsFolderUpdate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	return resourceJenkinsFolderRead(ctx, d, meta)
+}
+
+func resourceJenkinsFolderDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(jenkinsClient)
+	name, folders := parseCanonicalJobID(d.Id())
+
+	log.Printf("[DEBUG] jenkins::delete - Removing %q", name)
+
+	ok, err := client.DeleteJobInFolder(ctx, name, folders...)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[DEBUG] jenkins::delete - %q removed: %t", name, ok)
+	return nil
 }
 
 func expandSecurity(config []interface{}) *folderSecurity {


### PR DESCRIPTION
# What Is Changing

Preparing for the Framework migration by decoupling the `folder` resource's delete functionality from the `job` resource's functionality. These will now be maintained separately, allowing migration of the resources to occur separately.

# Test Steps

- [x] If you've changed documentation, have you run `make generate` to render the `docs/` folder?
- [x] Have you updated the `integration/` tests with a [terraform test](https://developer.hashicorp.com/terraform/language/tests) compatible change?

<!-- Additional test steps go here. -->
