### PR TITLE
Ensure resource names cannot include path characters

### DIFF
--- a/jenkins/resource.go
+++ b/jenkins/resource.go
@@ -3,6 +3,7 @@ package jenkins
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -86,6 +87,12 @@ func (r *resourceHelper) schema(s map[string]schema.Attribute) map[string]schema
 			MarkdownDescription: "The name of the resource being created. This maps to the ID property within Jenkins, and cannot be changed once set.",
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
+			},
+			Validators: []validator.String{
+				stringvalidator.RegexMatches(
+					regexp.MustCompile(`^[^/]*$`),
+					"must not include path characters. Please use the 'folder' property if specifying a job within a subfolder",
+				),
 			},
 		}
 	}


### PR DESCRIPTION
# What Is Changing

Adding a new validation to Framework-based resources that the `name` property cannot include path characters. The error message guides the user to a more appropriate use of the `folder` resource.

# Test Steps

- [x] If you've changed documentation, have you run `make generate` to render the `docs/` folder?
- [x] Have you updated the `integration/` tests with a [terraform test](https://developer.hashicorp.com/terraform/language/tests) compatible change?

<!-- Additional test steps go here. -->
