### PR TITLE
Add integration test assertions for folders

### DIFF
--- a/integration/jobs/folder.tf
+++ b/integration/jobs/folder.tf
@@ -12,8 +12,19 @@ resource "jenkins_folder" "example" {
   }
 }
 
+data "jenkins_folder" "example" {
+  depends_on = [jenkins_folder.example]
+  name       = jenkins_folder.example.name
+}
+
 resource "jenkins_folder" "example_subfolder" {
   name        = "subfolder"
   folder      = jenkins_folder.example.id
   description = "A sample subfolder"
+}
+
+data "jenkins_folder" "example_subfolder" {
+  depends_on = [jenkins_folder.example_subfolder]
+  name       = jenkins_folder.example_subfolder.name
+  folder     = jenkins_folder.example_subfolder.folder
 }

--- a/integration/jobs/view.tf
+++ b/integration/jobs/view.tf
@@ -9,7 +9,3 @@ data "jenkins_view" "example" {
   depends_on = [jenkins_view.example]
   name       = "example"
 }
-
-output "view" {
-  value = data.jenkins_view.example
-}

--- a/integration/main.tftest.hcl
+++ b/integration/main.tftest.hcl
@@ -26,6 +26,22 @@ run "jobs" {
   }
 
   assert {
+    condition     = chomp(data.jenkins_folder.example.template) == chomp(jenkins_folder.example.template)
+    error_message = "${data.jenkins_folder.example.name} produced inconsistent XML"
+  }
+  assert {
+    condition     = data.jenkins_folder.example.description == jenkins_folder.example.description
+    error_message = "${data.jenkins_folder.example.name} did not match description"
+  }
+  assert {
+    condition     = chomp(data.jenkins_folder.example_subfolder.template) == chomp(jenkins_folder.example_subfolder.template)
+    error_message = "${data.jenkins_folder.example_subfolder.name} produced inconsistent XML"
+  }
+  assert {
+    condition     = data.jenkins_folder.example_subfolder.description == jenkins_folder.example_subfolder.description
+    error_message = "${data.jenkins_folder.example_subfolder.name} did not match description"
+  }
+  assert {
     condition     = chomp(coalesce(data.jenkins_job.pipeline_scm.template, "")) == chomp(local.pipeline_scm_template)
     error_message = "${data.jenkins_job.pipeline_scm.name} produced inconsistent XML"
   }
@@ -38,8 +54,8 @@ run "jobs" {
     error_message = "${data.jenkins_job.freestyle.name} produced inconsistent XML"
   }
   assert {
-    condition     = output.view.name == "example"
-    error_message = "${output.view.name} did not contain expected \"example\" value"
+    condition     = data.jenkins_view.example.name == "example"
+    error_message = "${data.jenkins_view.example.name} did not contain expected \"example\" value"
   }
 }
 


### PR DESCRIPTION
# What Is Changing

Adding new assertions for the `jenkins_folder` integration tests, ensuring that the Data Source outputs match the Resource outputs.

# Test Steps

- [x] If you've changed documentation, have you run `make generate` to render the `docs/` folder?
- [x] Have you updated the `integration/` tests with a [terraform test](https://developer.hashicorp.com/terraform/language/tests) compatible change?

<!-- Additional test steps go here. -->
