### PR TITLE
Add support for ignoring Jenkins plugin version updates in job configuration

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -15,6 +15,9 @@ resource "jenkins_job" "example" {
   template = templatefile("${path.module}/job.xml", {
     description = "An example job created from Terraform"
   })
+  
+  # Optional: Ignore plugin version changes from Jenkins updates
+  skip_plugins_version_update = true
 }
 ```
 
@@ -59,6 +62,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the job being created.
 * `folder` - (Optional) The folder namespace to store the job in. If creating in a nested folder structure you may separate folder names with `/`, such as `parent/child`. This name cannot be changed once the folder has been created, and all parent folders must be created in advance.
 * `template` - (Required) A Jenkins-compatible XML template to describe the job. You can retrieve an existing jobs' XML by appending `/config.xml` to its URL and viewing the source in your browser. The `template` property is rendered using a Golang template that takes the other resource arguments as variables. Do not include the XML prolog in the definition.
+* `skip_plugins_version_update` - (Optional) When set to `true`, ignores plugin version changes in the XML configuration during updates and refreshes. This prevents configuration drift when Jenkins updates plugins and modifies the XML accordingly. Default is `false`. Note: This only applies to existing jobs; newly created jobs will always use the template as provided.
 
 ## Attribute Reference
 

--- a/jenkins/resource_jenkins_job.go
+++ b/jenkins/resource_jenkins_job.go
@@ -40,6 +40,12 @@ func resourceJenkinsJob() *schema.Resource {
 				Required:         true,
 				DiffSuppressFunc: templateDiff,
 			},
+			"skip_plugins_version_update": {
+				Type:        schema.TypeBool,
+				Description: "If true, ignore plugin version changes in XML configuration during updates and refreshes.",
+				Optional:    true,
+				Default:     false,
+			},
 		},
 	}
 }

--- a/jenkins/util.go
+++ b/jenkins/util.go
@@ -77,6 +77,18 @@ func folderExists(ctx context.Context, client jenkinsClient, name string) error 
 }
 
 func templateDiff(k, old, new string, d *schema.ResourceData) bool {
+	// Check if we should skip plugin version updates - do this BEFORE any XML manipulation
+	skipPluginVersions := false
+	if v, ok := d.GetOk("skip_plugins_version_update"); ok {
+		skipPluginVersions = v.(bool)
+	}
+
+	// Normalize plugin versions FIRST, before any string manipulation (only for existing jobs)
+	if skipPluginVersions && old != "" {
+		old = NormalizeXMLPluginVersions(old)
+		new = NormalizeXMLPluginVersions(new)
+	}
+
 	// Sanitize the XML entries to prevent inadvertent inequalities
 	re := regexp.MustCompile(`<\?xml.+\?>`)
 	old = re.ReplaceAllString(old, "")
@@ -91,6 +103,13 @@ func templateDiff(k, old, new string, d *schema.ResourceData) bool {
 	log.Printf("[DEBUG] jenkins::diff - Old: %q", old)
 	log.Printf("[DEBUG] jenkins::diff - New: %q", new)
 	return old == new
+}
+
+// NormalizeXMLPluginVersions removes plugin version from XML attributes
+func NormalizeXMLPluginVersions(xmlStr string) string {
+	// Remove plugin versions using regex: plugin="name@version" -> plugin="name"
+	re := regexp.MustCompile(`plugin="([^"@]+)@[^"]*"`)
+	return re.ReplaceAllString(xmlStr, `plugin="$1"`)
 }
 
 func generateCredentialID(folder, name string) string {

--- a/jenkins/util_test.go
+++ b/jenkins/util_test.go
@@ -133,3 +133,81 @@ func TestGenerateCredentialID(t *testing.T) {
 		t.Errorf("Expected %s/%s but got: %s", inputFolder, inputName, actual)
 	}
 }
+
+func TestNormalizeXMLPluginVersions(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "single plugin",
+			input:    `<flow-definition plugin="workflow-job@2.25">`,
+			expected: `<flow-definition plugin="workflow-job">`,
+		},
+		{
+			name:     "multiple plugins",
+			input:    `<flow-definition plugin="workflow-job@2.25"><definition plugin="workflow-cps@2.59">`,
+			expected: `<flow-definition plugin="workflow-job"><definition plugin="workflow-cps">`,
+		},
+		{
+			name:     "no plugins",
+			input:    `<project><description>test</description></project>`,
+			expected: `<project><description>test</description></project>`,
+		},
+		{
+			name:     "mixed content",
+			input:    `<scm class="hudson.plugins.git.GitSCM" plugin="git@3.9.1"><url>test</url></scm>`,
+			expected: `<scm class="hudson.plugins.git.GitSCM" plugin="git"><url>test</url></scm>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := NormalizeXMLPluginVersions(tt.input)
+			if actual != tt.expected {
+				t.Errorf("Expected %s but got: %s", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestTemplateDiff_SkipPluginVersions(t *testing.T) {
+	// Set up Job
+	job := resourceJenkinsJob()
+
+	// Test case 1: skip_plugins_version_update = true, should ignore version differences
+	bagWithSkip := job.TestResourceData()
+	_ = bagWithSkip.Set("skip_plugins_version_update", true)
+
+	inputOld := `<flow-definition plugin="workflow-job@2.25"><definition plugin="workflow-cps@2.59"></definition></flow-definition>`
+	inputNew := `<flow-definition plugin="workflow-job@3.0"><definition plugin="workflow-cps@3.0"></definition></flow-definition>`
+
+	if actual := templateDiff("", inputOld, inputNew, bagWithSkip); !actual {
+		t.Errorf("Expected XMLs with different plugin versions to be considered equal when skip_plugins_version_update=true")
+	}
+
+	// Test case 2: skip_plugins_version_update = false, should detect version differences
+	bagWithoutSkip := job.TestResourceData()
+	_ = bagWithoutSkip.Set("skip_plugins_version_update", false)
+
+	if actual := templateDiff("", inputOld, inputNew, bagWithoutSkip); actual {
+		t.Errorf("Expected XMLs with different plugin versions to be considered inequal when skip_plugins_version_update=false")
+	}
+
+	// Test case 3: skip_plugins_version_update = true but old is empty (create), should not skip
+	inputOldEmpty := ""
+	inputNewCreate := `<flow-definition plugin="workflow-job@2.25"></flow-definition>`
+
+	if actual := templateDiff("", inputOldEmpty, inputNewCreate, bagWithSkip); actual {
+		t.Errorf("Expected comparison with empty old value to work normally even with skip_plugins_version_update=true")
+	}
+
+	// Test case 4: skip_plugins_version_update = true, but actual content differs
+	inputOldDifferent := `<flow-definition plugin="workflow-job@2.25"><description>old</description></flow-definition>`
+	inputNewDifferent := `<flow-definition plugin="workflow-job@3.0"><description>new</description></flow-definition>`
+
+	if actual := templateDiff("", inputOldDifferent, inputNewDifferent, bagWithSkip); actual {
+		t.Errorf("Expected XMLs with different content to be considered inequal even when skip_plugins_version_update=true")
+	}
+}

--- a/templates/resources/job.md.tmpl
+++ b/templates/resources/job.md.tmpl
@@ -15,6 +15,9 @@ resource "jenkins_job" "example" {
   template = templatefile("${path.module}/job.xml", {
     description = "An example job created from Terraform"
   })
+  
+  # Optional: Ignore plugin version changes from Jenkins updates
+  skip_plugins_version_update = true
 }
 ```
 
@@ -59,6 +62,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the job being created.
 * `folder` - (Optional) The folder namespace to store the job in. If creating in a nested folder structure you may separate folder names with `/`, such as `parent/child`. This name cannot be changed once the folder has been created, and all parent folders must be created in advance.
 * `template` - (Required) A Jenkins-compatible XML template to describe the job. You can retrieve an existing jobs' XML by appending `/config.xml` to its URL and viewing the source in your browser. The `template` property is rendered using a Golang template that takes the other resource arguments as variables. Do not include the XML prolog in the definition.
+* `skip_plugins_version_update` - (Optional) When set to `true`, ignores plugin version changes in the XML configuration during updates and refreshes. This prevents configuration drift when Jenkins updates plugins and modifies the XML accordingly. Default is `false`. Note: This only applies to existing jobs; newly created jobs will always use the template as provided.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Problem

When Jenkins updates plugins, it automatically modifies the plugin versions in job XML configurations. This causes constant configuration drift in Terraform, even when the actual job configuration hasn't changed. Users have to either accept these unwanted changes or manually adjust their templates after every Jenkins plugin update.

### Dependencies

No additional dependencies required. This change uses existing functionality from the Terraform SDK and Go standard library.

### What Is Changing

**New Feature:**
- Added optional `skip_plugins_version_update` parameter to `jenkins_job` resource
  - Type: `bool`
  - Default: `false`
  - When enabled, ignores plugin version changes in XML during updates and refreshes

**Implementation:**
- New `NormalizeXMLPluginVersions()` function that strips version numbers from plugin attributes (`plugin="name@version"` → `plugin="name"`)
- Updated `templateDiff()` function to normalize XML when `skip_plugins_version_update` is enabled
- Feature only applies to existing jobs; newly created jobs always use the template as provided

**Files Modified:**
- `jenkins/resource_jenkins_job.go` - Added new schema attribute
- `jenkins/util.go` - Added normalization function and updated diff logic
- `jenkins/util_test.go` - Added comprehensive unit tests
- `docs/resources/job.md` - Updated documentation with usage example

**Usage Example:**
```hcl
resource "jenkins_job" "example" {
  name   = "my-pipeline"
  folder = "/folder/path"
  
  template = templatefile("${path.module}/job.xml", {
    description = "An example job"
  })
  
  # Ignore plugin version changes from Jenkins updates
  skip_plugins_version_update = true
}
```

**Backward Compatibility:**
Fully backward compatible - feature is opt-in and default behavior unchanged.

### Test Steps

- [x] If you've changed documentation, have you run `make generate` to render the `docs/` folder?
  - Updated template in `templates/resources/job.md.tmpl`
  - Ran `make generate` to regenerate documentation
- [ ] Have you updated the `integration/` tests with a [terraform test](https://developer.hashicorp.com/terraform/language/tests) compatible change?

**Completed Testing:**
- Added `TestNormalizeXMLPluginVersions` - validates XML normalization across multiple scenarios (single/multiple plugins, no plugins, mixed content)
- Added `TestTemplateDiff_SkipPluginVersions` - validates integration with diff logic and edge cases:
  - Plugin version differences ignored when enabled
  - Plugin version differences detected when disabled
  - Feature bypassed during job creation (empty old value)
  - Actual content changes still detected even with feature enabled
- All existing unit tests pass
- Code compiles without errors or linter warnings

**Integration Test Note:**
This feature addresses configuration drift rather than core functionality. Existing integration tests continue to validate job creation/updates with the new parameter present. Adding specific integration tests for plugin version drift would require simulating Jenkins plugin updates (manually modifying job XML in Jenkins and checking for drift), which is complex to automate and better suited for manual acceptance testing. The comprehensive unit tests provide full coverage of the normalization logic and diff behavior.

