### PR TITLE
fix(): remove xml version replacement in handleXml hack

### DIFF
--- a/jenkins/folder.go
+++ b/jenkins/folder.go
@@ -54,6 +54,12 @@ func handleXml(def string) []byte {
 	// This is a horrible practice...but Go doesn't seem to have any mature
 	// support for the XML 1.1 specification. As long as Jenkins doesn't make
 	// use of any 1.1 additions then this should still parse.
-	def = strings.ReplaceAll(def, `<?xml version='1.1' encoding='UTF-8'?>`, `<?xml version='1.0' encoding='UTF-8'?>`)
+	// Since Go’s XML parser doesn't require the XML declaration at all we can just drop it.
+	if strings.HasPrefix(def, "<?xml") {
+		end := strings.Index(def, "?>")
+		if end != -1 {
+			def = def[end+2:]
+		}
+	}
 	return []byte(def)
 }


### PR DESCRIPTION
# Dependencies

N/A

# What Is Changing

The Go xml parser does not require the version information. This is a fix for an upstream change where the xml version is now using " instead of ' for strings, so the replacement does not catch anymore, resulting in "Error: could not parse job XML: xml: unsupported version "1.1"; only version 1.0 is supported".

# Test Steps

- [ ] If you've changed documentation, have you run `make generate` to render the `docs/` folder?
- [ ] Have you updated the `integration/` tests with a [terraform test](https://developer.hashicorp.com/terraform/language/tests) compatible change?

<!-- Additional test steps go here. -->

I tested this against my jenkins installation that is running 2.571 but this is backwards compatible.