### PR TITLE
Add opt-in skip_plugins_version_update to jenkins_job

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -59,6 +59,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the job being created.
 * `folder` - (Optional) The folder namespace to store the job in. If creating in a nested folder structure you may separate folder names with `/`, such as `parent/child`. This name cannot be changed once the folder has been created, and all parent folders must be created in advance.
 * `template` - (Required) A Jenkins-compatible XML template to describe the job. You can retrieve an existing jobs' XML by appending `/config.xml` to its URL and viewing the source in your browser. The `template` property is rendered using a Golang template that takes the other resource arguments as variables. Do not include the XML prolog in the definition.
+* `skip_plugins_version_update` - (Optional) When `true`, plugin version changes in the job's XML are ignored when detecting drift. Jenkins rewrites `plugin="name@version"` attributes (e.g. `plugin="git@5.2.1"` -> `plugin="git@5.3.0"`) on every plugin upgrade, which otherwise appears as perpetual drift on `terraform plan`. Only diff detection is affected — the `template` pushed to Jenkins is unchanged, and a genuine plugin swap (different name) or any other content change is still reported. Defaults to `false`.
 
 ## Attribute Reference
 

--- a/jenkins/resource_jenkins_job.go
+++ b/jenkins/resource_jenkins_job.go
@@ -40,6 +40,12 @@ func resourceJenkinsJob() *schema.Resource {
 				Required:         true,
 				DiffSuppressFunc: templateDiff,
 			},
+			"skip_plugins_version_update": {
+				Type:        schema.TypeBool,
+				Description: "When enabled, plugin version changes in the job's XML (e.g. plugin=\"git@5.2.1\" -> plugin=\"git@5.3.0\") are ignored during plan. Jenkins rewrites these on every plugin upgrade, which otherwise surfaces as perpetual drift. The template pushed to Jenkins is unchanged; only diff detection is affected.",
+				Optional:    true,
+				Default:     false,
+			},
 		},
 	}
 }

--- a/jenkins/util.go
+++ b/jenkins/util.go
@@ -76,17 +76,30 @@ func folderExists(ctx context.Context, client jenkinsClient, name string) error 
 	return nil
 }
 
+var (
+	xmlDeclRe       = regexp.MustCompile(`<\?xml.+\?>`)
+	pluginVersionRe = regexp.MustCompile(`(plugin="[^"@]+)@[^"]*"`)
+)
+
+// normalizeTemplate sanitizes a Jenkins job config so functionally-equal XML
+// compares equal. When skipPluginVersions is set, plugin versions are dropped
+// because Jenkins rewrites the plugin="name@version" attributes on every plugin
+// upgrade, which would otherwise surface as perpetual job drift.
+func normalizeTemplate(s string, skipPluginVersions bool) string {
+	s = xmlDeclRe.ReplaceAllString(s, "")
+	if skipPluginVersions {
+		s = pluginVersionRe.ReplaceAllString(s, `$1"`)
+	}
+	s = strings.ReplaceAll(s, " ", "")
+	s = strings.TrimSpace(s)
+	return html.UnescapeString(s)
+}
+
 func templateDiff(k, old, new string, d *schema.ResourceData) bool {
-	// Sanitize the XML entries to prevent inadvertent inequalities
-	re := regexp.MustCompile(`<\?xml.+\?>`)
-	old = re.ReplaceAllString(old, "")
-	old = strings.ReplaceAll(old, " ", "")
-	old = strings.TrimSpace(old)
-	old = html.UnescapeString(old)
-	new = re.ReplaceAllString(new, "")
-	new = strings.ReplaceAll(new, " ", "")
-	new = strings.TrimSpace(new)
-	new = html.UnescapeString(new)
+	// Comma-ok: templateDiff is shared with resources that lack this field.
+	skipPluginVersions, _ := d.Get("skip_plugins_version_update").(bool)
+	old = normalizeTemplate(old, skipPluginVersions)
+	new = normalizeTemplate(new, skipPluginVersions)
 
 	log.Printf("[DEBUG] jenkins::diff - Old: %q", old)
 	log.Printf("[DEBUG] jenkins::diff - New: %q", new)

--- a/jenkins/util_test.go
+++ b/jenkins/util_test.go
@@ -108,6 +108,36 @@ func TestTemplateDiff(t *testing.T) {
 	}
 }
 
+func TestTemplateDiff_SkipPluginVersions(t *testing.T) {
+	inputLeft := `<scm class="hudson.plugins.git.GitSCM" plugin="git@5.2.1"><branch/></scm>`
+	inputRight := `<scm class="hudson.plugins.git.GitSCM" plugin="git@5.3.0"><branch/></scm>`
+
+	// Feature disabled (default): a plugin version bump is a real diff.
+	bag := resourceJenkinsJob().TestResourceData()
+	if actual := templateDiff("", inputLeft, inputRight, bag); actual {
+		t.Errorf("Expected plugin version bump to be reported when skip disabled: %s vs %s", inputLeft, inputRight)
+	}
+
+	// Feature enabled: a plugin version bump is suppressed.
+	bag = resourceJenkinsJob().TestResourceData()
+	_ = bag.Set("skip_plugins_version_update", true)
+	if actual := templateDiff("", inputLeft, inputRight, bag); !actual {
+		t.Errorf("Expected plugin version bump to be suppressed when skip enabled: %s vs %s", inputLeft, inputRight)
+	}
+
+	// Even enabled, a genuine plugin swap (different name) is still reported.
+	inputRight = `<scm class="hudson.plugins.git.GitSCM" plugin="git-client@5.3.0"><branch/></scm>`
+	if actual := templateDiff("", inputLeft, inputRight, bag); actual {
+		t.Errorf("Expected plugin name change to be reported: %s vs %s", inputLeft, inputRight)
+	}
+
+	// Even enabled, a real content change alongside a version bump is still reported.
+	inputRight = `<scm class="hudson.plugins.git.GitSCM" plugin="git@5.3.0"><branch>main</branch></scm>`
+	if actual := templateDiff("", inputLeft, inputRight, bag); actual {
+		t.Errorf("Expected content change to be reported despite skip: %s vs %s", inputLeft, inputRight)
+	}
+}
+
 func TestTemplateDiff_HTMLEntities(t *testing.T) {
 	job := resourceJenkinsFolder()
 	bag := job.TestResourceData()

--- a/templates/resources/job.md.tmpl
+++ b/templates/resources/job.md.tmpl
@@ -59,6 +59,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the job being created.
 * `folder` - (Optional) The folder namespace to store the job in. If creating in a nested folder structure you may separate folder names with `/`, such as `parent/child`. This name cannot be changed once the folder has been created, and all parent folders must be created in advance.
 * `template` - (Required) A Jenkins-compatible XML template to describe the job. You can retrieve an existing jobs' XML by appending `/config.xml` to its URL and viewing the source in your browser. The `template` property is rendered using a Golang template that takes the other resource arguments as variables. Do not include the XML prolog in the definition.
+* `skip_plugins_version_update` - (Optional) When `true`, plugin version changes in the job's XML are ignored when detecting drift. Jenkins rewrites `plugin="name@version"` attributes (e.g. `plugin="git@5.2.1"` -> `plugin="git@5.3.0"`) on every plugin upgrade, which otherwise appears as perpetual drift on `terraform plan`. Only diff detection is affected — the `template` pushed to Jenkins is unchanged, and a genuine plugin swap (different name) or any other content change is still reported. Defaults to `false`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
# Dependencies

None. Uses the existing Terraform SDK and Go stdlib only.

# What Is Changing

When Jenkins upgrades a plugin it rewrites the `plugin="name@version"` attributes inside every affected job's `config.xml` (e.g. `plugin="git@5.2.1"` → `plugin="git@5.3.0"`). Because `jenkins_job.template` compares the stored XML verbatim, this surfaces as perpetual `terraform plan` drift even though the job hasn't functionally changed.

This adds an **opt-in** `skip_plugins_version_update` (bool, default `false`) attribute to `jenkins_job`:

- `jenkins/resource_jenkins_job.go` — new schema attribute.
- `jenkins/util.go` — `templateDiff` now strips plugin versions before comparison **only when the flag is set**, via a `normalizeTemplate` helper. Both diff regexes are hoisted to package-level compiled vars.
- `jenkins/util_test.go` — unit tests covering both flag states, a genuine plugin swap (different name → still reported), and a real content change alongside a version bump (→ still reported).
- `docs/` + `templates/` — documented the attribute (`make generate` run).

Behavior is fully backward compatible: default off, and the flag affects **diff detection only** — the `template` pushed to Jenkins is unchanged, and any change beyond plugin versions (including a plugin *swap*) is still reported.

Supersedes the stale #251 (same idea and opt-in shape); thanks to @b8dmin for the original approach.

# Test Steps

- [x] If you've changed documentation, have you run `make generate` to render the `docs/` folder?
- [ ] Have you updated the `integration/` tests with a [terraform test](https://developer.hashicorp.com/terraform/language/tests) compatible change?
  - Not added: exercising the suppression end-to-end requires a real Jenkins-side plugin *upgrade* rewriting the job XML out-of-band, which can't be forced deterministically in the integration harness. The normalization and diff logic are fully covered by unit tests.
